### PR TITLE
ci: use repo variable for OPENCODE_MODEL

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -36,4 +36,4 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: ${{ secrets.OPENCODE_MODEL }}
+          model: ${{ vars.OPENCODE_MODEL }}


### PR DESCRIPTION
## Summary
- Change OPENCODE_MODEL from secret to repository variable
- Only OPENCODE_API_KEY remains as secret (sensitive)