### PR TITLE
fix: use port 5433 for db host mapping to avoid conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: ${DB_USER:-medminder}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-medminder}
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "${DB_PORT:-5433}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:
@@ -35,7 +35,7 @@ services:
       DB_USER: ${DB_USER:-medminder}
       DB_PASSWORD: ${DB_PASSWORD:-medminder}
       DB_NAME: ${DB_NAME:-medminder}
-      DB_SSLMODE: ${DB_SSLMODE:-disable}
+      DB_SSLMODE: ${DB_SSLMODE:-false}
     ports:
       - "${APP_PORT:-8080}:8080"
       - "${WEB_PORT:-5173}:5173"


### PR DESCRIPTION
## Summary
- Change PostgreSQL host port mapping from 5432 to 5433 to avoid conflict with OrbStack's local PostgreSQL
- Also fixed DB_SSLMODE value from "disable" to "false" (Go expects boolean string)