### PR TITLE
fix(auth): return specific validation error messages

### DIFF
--- a/internal/features/auth/handlers/register.go
+++ b/internal/features/auth/handlers/register.go
@@ -13,7 +13,6 @@ import (
 
 var (
 	ErrEmailExists     = errors.New("email already exists")
-	ErrInvalidInput    = errors.New("invalid input")
 	bcryptCost         = 12
 	refreshTokenExpiry = 7 * 24 * time.Hour
 )
@@ -44,13 +43,13 @@ type TokenServiceInterface interface {
 func RegisterHandler(repo repository.UserRepository, tokenSvc TokenServiceInterface) func(context.Context, *RegisterInput) (*RegisterOutput, error) {
 	return func(ctx context.Context, input *RegisterInput) (*RegisterOutput, error) {
 		if err := ValidateEmail(input.Email); err != nil {
-			return nil, ErrInvalidInput
+			return nil, ErrInvalidEmail
 		}
 		if err := ValidatePassword(input.Password); err != nil {
-			return nil, ErrInvalidInput
+			return nil, ErrInvalidPassword
 		}
 		if err := ValidateDisplayName(input.DisplayName); err != nil {
-			return nil, ErrInvalidInput
+			return nil, ErrInvalidDisplayName
 		}
 
 		existingUser, err := repo.GetUserByEmail(ctx, input.Email)

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -41,8 +41,14 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string) {
 	}, func(ctx context.Context, input *handlers.RegisterInput) (*registerOutput, error) {
 		resp, err := handler(ctx, input)
 		if err != nil {
-			if errors.Is(err, handlers.ErrInvalidInput) {
-				return nil, huma.Error400BadRequest("Invalid input", err)
+			if errors.Is(err, handlers.ErrInvalidEmail) {
+				return nil, huma.Error400BadRequest("Invalid email format", err)
+			}
+			if errors.Is(err, handlers.ErrInvalidPassword) {
+				return nil, huma.Error400BadRequest("Password must be at least 8 characters with 1 uppercase, 1 lowercase, and 1 number", err)
+			}
+			if errors.Is(err, handlers.ErrInvalidDisplayName) {
+				return nil, huma.Error400BadRequest("Display name must be 1-100 characters", err)
 			}
 			if errors.Is(err, handlers.ErrEmailExists) {
 				return nil, huma.Error409Conflict("Email already exists", err)


### PR DESCRIPTION
## Summary
- Replace generic "invalid input" error with specific validation errors
- Error messages now indicate exact failure: email format, password requirements, display name length