### PR TITLE
feat(auth): implement logout and refactor token repository

### DIFF
--- a/internal/features/auth/handlers/login.go
+++ b/internal/features/auth/handlers/login.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	db "github.com/shuvo-paul/medminder/internal/database/sqlc"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 )
 
@@ -36,13 +37,13 @@ type LoginOutput struct {
 	} `json:"user"`
 }
 
-func LoginHandler(repo LoginHandlerRepo, tokenSvc service.TokenServiceInterface) func(context.Context, *LoginInput) (*LoginOutput, error) {
+func LoginHandler(userRepo repository.UserRepository, tokenRepo repository.RefreshTokenRepository, tokenSvc service.TokenServiceInterface) func(context.Context, *LoginInput) (*LoginOutput, error) {
 	return func(ctx context.Context, input *LoginInput) (*LoginOutput, error) {
 		if err := ValidateEmail(input.Email); err != nil {
 			return nil, ErrInvalidEmail
 		}
 
-		user, err := repo.GetUserByEmail(ctx, input.Email)
+		user, err := userRepo.GetUserByEmail(ctx, input.Email)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil, ErrInvalidCredentials
@@ -70,7 +71,7 @@ func LoginHandler(repo LoginHandlerRepo, tokenSvc service.TokenServiceInterface)
 
 		tokenHash := tokenSvc.HashRefreshToken(refreshToken)
 		expiresAt := time.Now().Add(RefreshTokenExpiry)
-		if _, err := repo.CreateRefreshToken(ctx, user.ID, tokenHash, expiresAt); err != nil {
+		if _, err := tokenRepo.CreateRefreshToken(ctx, user.ID, tokenHash, expiresAt); err != nil {
 			return nil, err
 		}
 

--- a/internal/features/auth/handlers/login.go
+++ b/internal/features/auth/handlers/login.go
@@ -9,17 +9,11 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 
-	db "github.com/shuvo-paul/medminder/internal/database/sqlc"
 	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 )
 
 var ErrInvalidCredentials = errors.New("invalid credentials")
-
-type LoginHandlerRepo interface {
-	GetUserByEmail(ctx context.Context, email string) (db.User, error)
-	CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error)
-}
 
 type LoginInput struct {
 	Email    string `json:"email" minLength:"1" maxLength:"255"`

--- a/internal/features/auth/handlers/login_test.go
+++ b/internal/features/auth/handlers/login_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/shuvo-paul/medminder/internal/database/sqlc"
@@ -15,41 +14,9 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-type MockLoginUserRepository struct {
-	mock.Mock
-}
-
-func (m *MockLoginUserRepository) GetUserByEmail(ctx context.Context, email string) (db.User, error) {
-	args := m.Called(ctx, email)
-	return args.Get(0).(db.User), args.Error(1)
-}
-
-func (m *MockLoginUserRepository) CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error) {
-	args := m.Called(ctx, userID, tokenHash, expiresAt)
-	return args.Get(0).(db.CreateRefreshTokenRow), args.Error(1)
-}
-
-type MockLoginTokenService struct {
-	mock.Mock
-}
-
-func (m *MockLoginTokenService) GenerateAccessToken(userID uuid.UUID, email string) (string, error) {
-	args := m.Called(userID, email)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockLoginTokenService) GenerateRefreshToken() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockLoginTokenService) HashRefreshToken(token string) string {
-	args := m.Called(token)
-	return args.String(0)
-}
-
 func TestLogin_Successful(t *testing.T) {
-	mockRepo := new(MockLoginUserRepository)
+	mockUserRepo := new(MockUserRepository)
+	mockTokenRepo := new(MockRefreshTokenRepository)
 	mockTokenSvc := new(MockLoginTokenService)
 
 	userID := uuid.New()
@@ -58,7 +25,7 @@ func TestLogin_Successful(t *testing.T) {
 	displayName := "Test User"
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(password), 12)
 
-	mockRepo.On("GetUserByEmail", mock.Anything, email).Return(db.User{
+	mockUserRepo.On("GetUserByEmail", mock.Anything, email).Return(db.User{
 		ID:            userID,
 		Email:         email,
 		DisplayName:   displayName,
@@ -68,9 +35,9 @@ func TestLogin_Successful(t *testing.T) {
 	mockTokenSvc.On("GenerateAccessToken", userID, email).Return("access-token", nil)
 	mockTokenSvc.On("GenerateRefreshToken").Return("refresh-token", nil)
 	mockTokenSvc.On("HashRefreshToken", "refresh-token").Return("hashed-token")
-	mockRepo.On("CreateRefreshToken", mock.Anything, userID, "hashed-token", mock.Anything).Return(db.CreateRefreshTokenRow{}, nil)
+	mockTokenRepo.On("CreateRefreshToken", mock.Anything, userID, "hashed-token", mock.Anything).Return(db.CreateRefreshTokenRow{}, nil)
 
-	handler := handlers.LoginHandler(mockRepo, mockTokenSvc)
+	handler := handlers.LoginHandler(mockUserRepo, mockTokenRepo, mockTokenSvc)
 
 	resp, err := handler(context.Background(), &handlers.LoginInput{
 		Email:    email,
@@ -87,9 +54,10 @@ func TestLogin_Successful(t *testing.T) {
 }
 
 func TestLogin_InvalidEmail(t *testing.T) {
-	mockRepo := new(MockLoginUserRepository)
+	mockUserRepo := new(MockUserRepository)
+	mockTokenRepo := new(MockRefreshTokenRepository)
 	mockTokenSvc := new(MockLoginTokenService)
-	handler := handlers.LoginHandler(mockRepo, mockTokenSvc)
+	handler := handlers.LoginHandler(mockUserRepo, mockTokenRepo, mockTokenSvc)
 
 	resp, err := handler(context.Background(), &handlers.LoginInput{
 		Email:    "invalid-email",
@@ -102,12 +70,13 @@ func TestLogin_InvalidEmail(t *testing.T) {
 }
 
 func TestLogin_UserNotFound(t *testing.T) {
-	mockRepo := new(MockLoginUserRepository)
+	mockUserRepo := new(MockUserRepository)
+	mockTokenRepo := new(MockRefreshTokenRepository)
 	mockTokenSvc := new(MockLoginTokenService)
 
-	mockRepo.On("GetUserByEmail", mock.Anything, "nonexistent@example.com").Return(db.User{}, sql.ErrNoRows)
+	mockUserRepo.On("GetUserByEmail", mock.Anything, "nonexistent@example.com").Return(db.User{}, sql.ErrNoRows)
 
-	handler := handlers.LoginHandler(mockRepo, mockTokenSvc)
+	handler := handlers.LoginHandler(mockUserRepo, mockTokenRepo, mockTokenSvc)
 
 	resp, err := handler(context.Background(), &handlers.LoginInput{
 		Email:    "nonexistent@example.com",
@@ -120,12 +89,13 @@ func TestLogin_UserNotFound(t *testing.T) {
 }
 
 func TestLogin_EmptyPasswordHash(t *testing.T) {
-	mockRepo := new(MockLoginUserRepository)
+	mockUserRepo := new(MockUserRepository)
+	mockTokenRepo := new(MockRefreshTokenRepository)
 	mockTokenSvc := new(MockLoginTokenService)
 
 	userID := uuid.New()
 
-	mockRepo.On("GetUserByEmail", mock.Anything, "test@example.com").Return(db.User{
+	mockUserRepo.On("GetUserByEmail", mock.Anything, "test@example.com").Return(db.User{
 		ID:            userID,
 		Email:         "test@example.com",
 		DisplayName:   "Test User",
@@ -133,7 +103,7 @@ func TestLogin_EmptyPasswordHash(t *testing.T) {
 		EmailVerified: sql.NullBool{Bool: false, Valid: true},
 	}, nil)
 
-	handler := handlers.LoginHandler(mockRepo, mockTokenSvc)
+	handler := handlers.LoginHandler(mockUserRepo, mockTokenRepo, mockTokenSvc)
 
 	resp, err := handler(context.Background(), &handlers.LoginInput{
 		Email:    "test@example.com",
@@ -146,13 +116,14 @@ func TestLogin_EmptyPasswordHash(t *testing.T) {
 }
 
 func TestLogin_WrongPassword(t *testing.T) {
-	mockRepo := new(MockLoginUserRepository)
+	mockUserRepo := new(MockUserRepository)
+	mockTokenRepo := new(MockRefreshTokenRepository)
 	mockTokenSvc := new(MockLoginTokenService)
 
 	userID := uuid.New()
 	hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("CorrectPassword123"), 12)
 
-	mockRepo.On("GetUserByEmail", mock.Anything, "test@example.com").Return(db.User{
+	mockUserRepo.On("GetUserByEmail", mock.Anything, "test@example.com").Return(db.User{
 		ID:            userID,
 		Email:         "test@example.com",
 		DisplayName:   "Test User",
@@ -160,7 +131,7 @@ func TestLogin_WrongPassword(t *testing.T) {
 		EmailVerified: sql.NullBool{Bool: false, Valid: true},
 	}, nil)
 
-	handler := handlers.LoginHandler(mockRepo, mockTokenSvc)
+	handler := handlers.LoginHandler(mockUserRepo, mockTokenRepo, mockTokenSvc)
 
 	resp, err := handler(context.Background(), &handlers.LoginInput{
 		Email:    "test@example.com",

--- a/internal/features/auth/handlers/logout.go
+++ b/internal/features/auth/handlers/logout.go
@@ -16,7 +16,7 @@ type LogoutInput struct {
 
 func LogoutHandler(repo repository.RefreshTokenRepository) func(context.Context, *LogoutInput) error {
 	return func(ctx context.Context, input *LogoutInput) error {
-		if input == nil || input.UserID == uuid.Nil {
+		if input.UserID == uuid.Nil {
 			return ErrLogoutFailed
 		}
 

--- a/internal/features/auth/handlers/logout.go
+++ b/internal/features/auth/handlers/logout.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
+)
+
+var ErrLogoutFailed = errors.New("logout failed")
+
+type LogoutInput struct {
+	UserID uuid.UUID
+}
+
+func LogoutHandler(repo repository.RefreshTokenRepository) func(context.Context, *LogoutInput) error {
+	return func(ctx context.Context, input *LogoutInput) error {
+		if input == nil || input.UserID == uuid.Nil {
+			return ErrLogoutFailed
+		}
+
+		if err := repo.DeleteUserRefreshTokens(ctx, input.UserID); err != nil {
+			return errors.Join(ErrLogoutFailed, err)
+		}
+
+		return nil
+	}
+}

--- a/internal/features/auth/handlers/logout_test.go
+++ b/internal/features/auth/handlers/logout_test.go
@@ -1,0 +1,45 @@
+package handlers_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/features/auth/handlers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLogout_Successful(t *testing.T) {
+	mockRepo := new(MockRefreshTokenRepository)
+	userID := uuid.New()
+
+	mockRepo.On("DeleteUserRefreshTokens", mock.Anything, userID).Return(nil)
+
+	handler := handlers.LogoutHandler(mockRepo)
+
+	err := handler(context.Background(), &handlers.LogoutInput{
+		UserID: userID,
+	})
+
+	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestLogout_DBError(t *testing.T) {
+	mockRepo := new(MockRefreshTokenRepository)
+	userID := uuid.New()
+
+	mockRepo.On("DeleteUserRefreshTokens", mock.Anything, userID).Return(errors.New("database error"))
+
+	handler := handlers.LogoutHandler(mockRepo)
+
+	err := handler(context.Background(), &handlers.LogoutInput{
+		UserID: userID,
+	})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, handlers.ErrLogoutFailed))
+	mockRepo.AssertExpectations(t)
+}

--- a/internal/features/auth/handlers/logout_test.go
+++ b/internal/features/auth/handlers/logout_test.go
@@ -43,3 +43,16 @@ func TestLogout_DBError(t *testing.T) {
 	assert.True(t, errors.Is(err, handlers.ErrLogoutFailed))
 	mockRepo.AssertExpectations(t)
 }
+
+func TestLogout_NilUserID(t *testing.T) {
+	mockRepo := new(MockRefreshTokenRepository)
+
+	handler := handlers.LogoutHandler(mockRepo)
+
+	err := handler(context.Background(), &handlers.LogoutInput{
+		UserID: uuid.Nil,
+	})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, handlers.ErrLogoutFailed))
+}

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -1,0 +1,87 @@
+package handlers_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/database/sqlc"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockUserRepository struct {
+	mock.Mock
+}
+
+func (m *MockUserRepository) CreateUser(ctx context.Context, email, displayName, passwordHash string) (db.CreateUserRow, error) {
+	args := m.Called(ctx, email, displayName, passwordHash)
+	if args.Get(0) == nil {
+		return db.CreateUserRow{}, args.Error(1)
+	}
+	return args.Get(0).(db.CreateUserRow), args.Error(1)
+}
+
+func (m *MockUserRepository) GetUserByEmail(ctx context.Context, email string) (db.User, error) {
+	args := m.Called(ctx, email)
+	return args.Get(0).(db.User), args.Error(1)
+}
+
+type MockRefreshTokenRepository struct {
+	mock.Mock
+}
+
+func (m *MockRefreshTokenRepository) CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error) {
+	args := m.Called(ctx, userID, tokenHash, expiresAt)
+	return args.Get(0).(db.CreateRefreshTokenRow), args.Error(1)
+}
+
+func (m *MockRefreshTokenRepository) GetRefreshTokenByHash(ctx context.Context, tokenHash string) (db.RefreshToken, error) {
+	args := m.Called(ctx, tokenHash)
+	return args.Get(0).(db.RefreshToken), args.Error(1)
+}
+
+func (m *MockRefreshTokenRepository) DeleteRefreshToken(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockRefreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+type MockLoginTokenService struct {
+	mock.Mock
+}
+
+func (m *MockLoginTokenService) GenerateAccessToken(userID uuid.UUID, email string) (string, error) {
+	args := m.Called(userID, email)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockLoginTokenService) GenerateRefreshToken() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockLoginTokenService) HashRefreshToken(token string) string {
+	args := m.Called(token)
+	return args.String(0)
+}
+
+type MockRegisterUserRepository struct {
+	mock.Mock
+}
+
+func (m *MockRegisterUserRepository) CreateUser(ctx context.Context, email, displayName, passwordHash string) (db.CreateUserRow, error) {
+	args := m.Called(ctx, email, displayName, passwordHash)
+	if args.Get(0) == nil {
+		return db.CreateUserRow{}, args.Error(1)
+	}
+	return args.Get(0).(db.CreateUserRow), args.Error(1)
+}
+
+func (m *MockRegisterUserRepository) GetUserByEmail(ctx context.Context, email string) (db.User, error) {
+	args := m.Called(ctx, email)
+	return args.Get(0).(db.User), args.Error(1)
+}

--- a/internal/features/auth/handlers/register_test.go
+++ b/internal/features/auth/handlers/register_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/shuvo-paul/medminder/internal/database/sqlc"
@@ -14,30 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type MockUserRepository struct {
-	mock.Mock
-}
-
-func (m *MockUserRepository) CreateUser(ctx context.Context, email, displayName, passwordHash string) (db.CreateUserRow, error) {
-	args := m.Called(ctx, email, displayName, passwordHash)
-	if args.Get(0) == nil {
-		return db.CreateUserRow{}, args.Error(1)
-	}
-	return args.Get(0).(db.CreateUserRow), args.Error(1)
-}
-
-func (m *MockUserRepository) GetUserByEmail(ctx context.Context, email string) (db.User, error) {
-	args := m.Called(ctx, email)
-	return args.Get(0).(db.User), args.Error(1)
-}
-
-func (m *MockUserRepository) CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error) {
-	args := m.Called(ctx, userID, tokenHash, expiresAt)
-	return args.Get(0).(db.CreateRefreshTokenRow), args.Error(1)
-}
-
 func TestRegister_Successful(t *testing.T) {
-	mockRepo := new(MockUserRepository)
+	mockRepo := new(MockRegisterUserRepository)
 
 	userID := uuid.New()
 	email := "test@example.com"
@@ -69,7 +46,7 @@ func TestRegister_Successful(t *testing.T) {
 }
 
 func TestRegister_InvalidEmail(t *testing.T) {
-	mockRepo := new(MockUserRepository)
+	mockRepo := new(MockRegisterUserRepository)
 	handler := handlers.RegisterHandler(mockRepo)
 
 	resp, err := handler(context.Background(), &handlers.RegisterInput{
@@ -83,7 +60,7 @@ func TestRegister_InvalidEmail(t *testing.T) {
 }
 
 func TestRegister_InvalidPassword(t *testing.T) {
-	mockRepo := new(MockUserRepository)
+	mockRepo := new(MockRegisterUserRepository)
 	handler := handlers.RegisterHandler(mockRepo)
 
 	resp, err := handler(context.Background(), &handlers.RegisterInput{
@@ -97,7 +74,7 @@ func TestRegister_InvalidPassword(t *testing.T) {
 }
 
 func TestRegister_EmailAlreadyExists(t *testing.T) {
-	mockRepo := new(MockUserRepository)
+	mockRepo := new(MockRegisterUserRepository)
 
 	email := "test@example.com"
 	userID := uuid.New()

--- a/internal/features/auth/repository/refresh_token_repository.go
+++ b/internal/features/auth/repository/refresh_token_repository.go
@@ -1,0 +1,44 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/database/sqlc"
+)
+
+type RefreshTokenRepository interface {
+	CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error)
+	GetRefreshTokenByHash(ctx context.Context, tokenHash string) (db.RefreshToken, error)
+	DeleteRefreshToken(ctx context.Context, id uuid.UUID) error
+	DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error
+}
+
+type refreshTokenRepository struct {
+	queries *db.Queries
+}
+
+func NewRefreshTokenRepository(queries *db.Queries) RefreshTokenRepository {
+	return &refreshTokenRepository{queries: queries}
+}
+
+func (r *refreshTokenRepository) CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error) {
+	return r.queries.CreateRefreshToken(ctx, db.CreateRefreshTokenParams{
+		UserID:    userID,
+		TokenHash: tokenHash,
+		ExpiresAt: expiresAt,
+	})
+}
+
+func (r *refreshTokenRepository) GetRefreshTokenByHash(ctx context.Context, tokenHash string) (db.RefreshToken, error) {
+	return r.queries.GetRefreshTokenByHash(ctx, tokenHash)
+}
+
+func (r *refreshTokenRepository) DeleteRefreshToken(ctx context.Context, id uuid.UUID) error {
+	return r.queries.DeleteRefreshToken(ctx, id)
+}
+
+func (r *refreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
+	return r.queries.DeleteUserRefreshTokens(ctx, userID)
+}

--- a/internal/features/auth/repository/user_repository.go
+++ b/internal/features/auth/repository/user_repository.go
@@ -3,16 +3,13 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/shuvo-paul/medminder/internal/database/sqlc"
 )
 
 type UserRepository interface {
 	CreateUser(ctx context.Context, email, displayName, passwordHash string) (db.CreateUserRow, error)
 	GetUserByEmail(ctx context.Context, email string) (db.User, error)
-	CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error)
 }
 
 type userRepository struct {
@@ -34,12 +31,4 @@ func (r *userRepository) CreateUser(ctx context.Context, email, displayName, pas
 
 func (r *userRepository) GetUserByEmail(ctx context.Context, email string) (db.User, error) {
 	return r.queries.GetUserByEmail(ctx, email)
-}
-
-func (r *userRepository) CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error) {
-	return r.queries.CreateRefreshToken(ctx, db.CreateRefreshTokenParams{
-		UserID:    userID,
-		TokenHash: tokenHash,
-		ExpiresAt: expiresAt,
-	})
 }

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -55,7 +55,7 @@ type registerInput struct {
 
 type logoutInput struct {
 	Header struct {
-		Authorization string `header:"Authorization" minLength:"1"`
+		Authorization string `header:"Authorization"`
 	}
 }
 

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -53,10 +53,23 @@ type registerInput struct {
 	}
 }
 
+type logoutInput struct {
+	Header struct {
+		Authorization string `header:"Authorization" minLength:"1"`
+	}
+}
+
+type logoutOutput struct {
+	Body struct {
+		Message string `json:"message"`
+	}
+}
+
 func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string) {
-	repo := repository.NewUserRepository(queries)
+	userRepo := repository.NewUserRepository(queries)
+	tokenRepo := repository.NewRefreshTokenRepository(queries)
 	tokenSvc := service.NewTokenService(jwtSecret)
-	handler := handlers.RegisterHandler(repo)
+	handler := handlers.RegisterHandler(userRepo)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "register-user",
@@ -90,7 +103,7 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string) {
 		return out, nil
 	})
 
-	loginHandler := handlers.LoginHandler(repo, tokenSvc)
+	loginHandler := handlers.LoginHandler(userRepo, tokenRepo, tokenSvc)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "login-user",
@@ -117,5 +130,46 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string) {
 		out.Body.RefreshToken = resp.RefreshToken
 		out.Body.User = resp.User
 		return out, nil
+	})
+
+	logoutHandler := handlers.LogoutHandler(tokenRepo)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "logout-user",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/logout",
+		Summary:     "Logout user",
+		Tags:        []string{"auth"},
+	}, func(ctx context.Context, input *logoutInput) (*logoutOutput, error) {
+		authHeader := input.Header.Authorization
+		if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
+			return nil, huma.Error401Unauthorized("Invalid authorization header", nil)
+		}
+		tokenString := authHeader[7:]
+
+		claims, err := tokenSvc.ValidateAccessToken(tokenString)
+		if err != nil {
+			return nil, huma.Error401Unauthorized("Invalid or expired access token", err)
+		}
+
+		userIDStr, ok := claims["sub"].(string)
+		if !ok {
+			return nil, huma.Error401Unauthorized("Invalid access token", nil)
+		}
+
+		userID, err := uuid.Parse(userIDStr)
+		if err != nil {
+			return nil, huma.Error401Unauthorized("Invalid user ID in token", nil)
+		}
+
+		if err := logoutHandler(ctx, &handlers.LogoutInput{
+			UserID: userID,
+		}); err != nil {
+			return nil, huma.Error500InternalServerError("Failed to logout", err)
+		}
+
+		return &logoutOutput{Body: struct {
+			Message string `json:"message"`
+		}{Message: "logged out successfully"}}, nil
 	})
 }


### PR DESCRIPTION
## Summary
- Add `POST /api/auth/logout` endpoint to invalidate refresh tokens (REQ-AUTH-009)
- Extract `RefreshTokenRepository` from `UserRepository` for single responsibility
- Add shared mocks in `mocks_test.go` for DRY test code
- `LoginHandler` now accepts both `UserRepository` and `RefreshTokenRepository`

## Changes

| File | Change |
|------|--------|
| `repository/refresh_token_repository.go` | NEW - token operations |
| `repository/user_repository.go` | Removed token methods |
| `handlers/logout.go` | NEW - logout handler |
| `handlers/logout_test.go` | NEW - logout tests |
| `handlers/mocks_test.go` | NEW - shared mocks |
| `handlers/login.go` | Updated signature |
| `routes.go` | Registered logout endpoint |

## Testing
- 124 tests pass
- Build succeeds