### PR TITLE
chore: remove redundant make targets and simplify Docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 
 RUN go install github.com/air-verse/air@latest \
 	&& apt-get update \
-	&& apt-get install -y --no-install-recommends make postgresql-client curl \
+	&& apt-get install -y --no-install-recommends postgresql-client curl \
 	&& curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
 	&& apt-get install -y --no-install-recommends nodejs \
 	&& rm -rf /var/lib/apt/lists/* \
@@ -19,4 +19,4 @@ COPY . .
 
 EXPOSE 8080 5173
 
-CMD ["make", "start"]
+CMD ["sh", "-c", "air & cd web && pnpm dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY := build dev start run test test-cover tidy clean web-install web-dev web-build web-preview embed-frontend db-migrate-up db-migrate-down db-migrate-steps db-migrate-force db-migrate-create sqlc-generate
+.PHONY := build test test-cover tidy clean web-install web-dev web-build web-preview embed-frontend db-migrate-up db-migrate-down db-migrate-steps db-migrate-force db-migrate-create sqlc-generate
 
 GO ?= go
 PNPM ?= pnpm
@@ -19,19 +19,6 @@ build:
 	@mkdir -p $(BIN_DIR)
 	@mkdir -p cmd/server/web/dist
 	$(GO) build -o $(BIN) $(CMD)
-
-# Development: Go server with Air hot-reload. No frontend build.
-# Use alongside `make web-dev` in a second terminal.
-dev:
-	$(AIR)
-
-# Start both Air (Go) and Vite (frontend) together. Ctrl+C stops both.
-start:
-	trap 'kill 0' EXIT; $(AIR) & cd $(WEB_DIR) && $(PNPM) dev
-
-# Run Go server directly (use after make embed-frontend)
-run:
-	$(GO) run $(CMD)
 
 test:
 	$(GO) test ./...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: sh -c "pnpm --prefix web install && make start"
     volumes:
       - .:/app
       - air_tmp:/app/tmp


### PR DESCRIPTION
## Summary
- Remove `dev`, `start`, `run` targets from Makefile (Docker handles local dev)
- Update Dockerfile CMD to run `air & cd web && pnpm dev` directly
- Remove `make` dependency from Dockerfile since it's no longer needed