### PR TITLE
feat(auth): wire password reset frontend pages

### DIFF
--- a/web/src/routes/auth/reset-password/+page.svelte
+++ b/web/src/routes/auth/reset-password/+page.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { goto } from '$app/navigation';
+
+	let token = $state('');
+	let newPassword = $state('');
+	let confirmPassword = $state('');
+	let showPassword = $state(false);
+	let errors = $state<Record<string, string>>({});
+	let isLoading = $state(false);
+	let generalError = $state('');
+
+	// Get token from URL on mount
+	$effect(() => {
+		const urlToken = $page.url.searchParams.get('token');
+		if (urlToken) {
+			token = urlToken;
+		} else {
+			// Redirect to login if no token
+			goto('/login');
+		}
+	});
+
+	function validateForm(): boolean {
+		const newErrors: Record<string, string> = {};
+		
+		if (!token) {
+			newErrors.token = 'Invalid reset token';
+		}
+		if (!newPassword) {
+			newErrors.newPassword = 'Password is required';
+		} else if (newPassword.length < 8) {
+			newErrors.newPassword = 'Password must be at least 8 characters';
+		}
+		if (!confirmPassword) {
+			newErrors.confirmPassword = 'Please confirm your password';
+		} else if (newPassword !== confirmPassword) {
+			newErrors.confirmPassword = 'Passwords do not match';
+		}
+
+		errors = newErrors;
+		return Object.keys(newErrors).length === 0;
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		generalError = '';
+		if (!validateForm()) return;
+
+		isLoading = true;
+		try {
+			const response = await fetch('/api/auth/password/reset/confirm', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ token, new_password: newPassword }),
+			});
+
+			if (!response.ok) {
+				const data = await response.json();
+				generalError = data.detail || 'Failed to reset password. Please try again.';
+				return;
+			}
+
+			goto('/login?reset=success');
+		} catch {
+			generalError = 'Network error. Please try again.';
+		} finally {
+			isLoading = false;
+		}
+	}
+</script>
+
+<div class="flex min-h-screen flex-col items-center justify-center px-4">
+	<div class="mb-8 text-center">
+		<h1 class="text-3xl font-bold tracking-tight">MedMinder</h1>
+		<p class="text-muted-foreground text-sm mt-1">Your personal medication reminder</p>
+	</div>
+
+	<div class="w-full max-w-sm">
+		<div class="mb-6 text-center">
+			<h2 class="text-xl font-semibold tracking-tight">Reset Password</h2>
+			<p class="text-muted-foreground text-sm mt-1">Enter your new password</p>
+		</div>
+
+		{#if generalError}
+			<div class="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+				{generalError}
+			</div>
+		{/if}
+
+		<form onsubmit={handleSubmit} class="space-y-5">
+			<input type="hidden" bind:value={token} />
+
+			<div class="space-y-2">
+				<Label for="newPassword">New Password</Label>
+				<div class="relative">
+					<Input
+						id="newPassword"
+						type={showPassword ? 'text' : 'password'}
+						placeholder="At least 8 characters"
+						bind:value={newPassword}
+						class="pr-10"
+						autocomplete="new-password"
+						aria-describedby={errors.newPassword ? 'newPassword-error' : undefined}
+						disabled={isLoading}
+					/>
+					<button
+						type="button"
+						onclick={() => (showPassword = !showPassword)}
+						class="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+						aria-label={showPassword ? 'Hide password' : 'Show password'}
+					>
+						{#if showPassword}
+							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+						{:else}
+							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+						{/if}
+					</button>
+				</div>
+				{#if errors.newPassword}
+					<p id="newPassword-error" class="text-sm text-destructive">{errors.newPassword}</p>
+				{/if}
+			</div>
+
+			<div class="space-y-2">
+				<Label for="confirmPassword">Confirm Password</Label>
+				<Input
+					id="confirmPassword"
+					type={showPassword ? 'text' : 'password'}
+					placeholder="Confirm your password"
+					bind:value={confirmPassword}
+					autocomplete="new-password"
+					aria-describedby={errors.confirmPassword ? 'confirmPassword-error' : undefined}
+					disabled={isLoading}
+				/>
+				{#if errors.confirmPassword}
+					<p id="confirmPassword-error" class="text-sm text-destructive">{errors.confirmPassword}</p>
+				{/if}
+			</div>
+
+			<Button type="submit" class="w-full" disabled={isLoading}>
+				{#if isLoading}
+					Resetting...
+				{:else}
+					Reset Password
+				{/if}
+			</Button>
+		</form>
+
+		<p class="mt-6 text-center text-sm text-muted-foreground">
+			Remember your password? <a href="/login" class="text-primary hover:underline">Sign in</a>
+		</p>
+	</div>
+</div>

--- a/web/src/routes/auth/reset-password/+page.svelte
+++ b/web/src/routes/auth/reset-password/+page.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { Eye, EyeOff } from '@lucide/svelte';
 	import { goto } from '$app/navigation';
 
 	let token = $state('');
@@ -32,8 +33,14 @@
 		}
 		if (!newPassword) {
 			newErrors.newPassword = 'Password is required';
-		} else if (newPassword.length < 8) {
+	} else if (newPassword.length < 8) {
 			newErrors.newPassword = 'Password must be at least 8 characters';
+		} else if (!/[A-Z]/.test(newPassword)) {
+			newErrors.newPassword = 'Password must contain at least 1 uppercase letter';
+		} else if (!/[a-z]/.test(newPassword)) {
+			newErrors.newPassword = 'Password must contain at least 1 lowercase letter';
+		} else if (!/[0-9]/.test(newPassword)) {
+			newErrors.newPassword = 'Password must contain at least 1 number';
 		}
 		if (!confirmPassword) {
 			newErrors.confirmPassword = 'Please confirm your password';
@@ -92,8 +99,6 @@
 		{/if}
 
 		<form onsubmit={handleSubmit} class="space-y-5">
-			<input type="hidden" bind:value={token} />
-
 			<div class="space-y-2">
 				<Label for="newPassword">New Password</Label>
 				<div class="relative">
@@ -102,6 +107,7 @@
 						type={showPassword ? 'text' : 'password'}
 						placeholder="At least 8 characters"
 						bind:value={newPassword}
+						variant={errors.newPassword ? 'error' : 'default'}
 						class="pr-10"
 						autocomplete="new-password"
 						aria-describedby={errors.newPassword ? 'newPassword-error' : undefined}
@@ -114,9 +120,9 @@
 						aria-label={showPassword ? 'Hide password' : 'Show password'}
 					>
 						{#if showPassword}
-							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+							<EyeOff class="h-4 w-4" />
 						{:else}
-							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+							<Eye class="h-4 w-4" />
 						{/if}
 					</button>
 				</div>
@@ -132,6 +138,7 @@
 					type={showPassword ? 'text' : 'password'}
 					placeholder="Confirm your password"
 					bind:value={confirmPassword}
+					variant={errors.confirmPassword ? 'error' : 'default'}
 					autocomplete="new-password"
 					aria-describedby={errors.confirmPassword ? 'confirmPassword-error' : undefined}
 					disabled={isLoading}

--- a/web/src/routes/auth/reset-password/+page.ts
+++ b/web/src/routes/auth/reset-password/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { goto } from '$app/navigation';
+
+	let email = $state('');
+	let errors = $state<Record<string, string>>({});
+	let isLoading = $state(false);
+	let generalError = $state('');
+	let successMessage = $state('');
+
+	function validateForm(): boolean {
+		const newErrors: Record<string, string> = {};
+		if (!email.trim()) {
+			newErrors.email = 'Email is required';
+		} else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+			newErrors.email = 'Please enter a valid email';
+		}
+		errors = newErrors;
+		return Object.keys(newErrors).length === 0;
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+		generalError = '';
+		successMessage = '';
+		if (!validateForm()) return;
+
+		isLoading = true;
+		try {
+			const response = await fetch('/api/auth/password/reset/request', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ email }),
+			});
+
+			if (!response.ok) {
+				const data = await response.json();
+				generalError = data.detail || 'Failed to send reset link. Please try again.';
+				return;
+			}
+
+			// Always show success message for security (don't reveal if email exists)
+			successMessage = 'If the email exists, a reset link has been sent';
+		} catch {
+			generalError = 'Network error. Please try again.';
+		} finally {
+			isLoading = false;
+		}
+	}
+</script>
+
+<div class="flex min-h-screen flex-col items-center justify-center px-4">
+	<div class="mb-8 text-center">
+		<h1 class="text-3xl font-bold tracking-tight">MedMinder</h1>
+		<p class="text-muted-foreground text-sm mt-1">Your personal medication reminder</p>
+	</div>
+
+	<div class="w-full max-w-sm">
+		<div class="mb-6 text-center">
+			<h2 class="text-xl font-semibold tracking-tight">Forgot Password</h2>
+			<p class="text-muted-foreground text-sm mt-1">Enter your email to receive a reset link</p>
+		</div>
+
+		{#if generalError}
+			<div class="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+				{generalError}
+			</div>
+		{/if}
+
+		{#if successMessage}
+			<div class="mb-4 rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400">
+				{successMessage}
+			</div>
+		{/if}
+
+		<form onsubmit={handleSubmit} class="space-y-5">
+			<div class="space-y-2">
+				<Label for="email">Email</Label>
+				<Input
+					id="email"
+					type="email"
+					placeholder="you@example.com"
+					bind:value={email}
+					autocomplete="email"
+					aria-describedby={errors.email ? 'email-error' : undefined}
+					disabled={isLoading}
+				/>
+				{#if errors.email}
+					<p id="email-error" class="text-sm text-destructive">{errors.email}</p>
+				{/if}
+			</div>
+
+			<Button type="submit" class="w-full" disabled={isLoading}>
+				{#if isLoading}
+					Sending...
+				{:else}
+					Send Reset Link
+				{/if}
+			</Button>
+		</form>
+
+		<p class="mt-6 text-center text-sm text-muted-foreground">
+			Remember your password? <a href="/login" class="text-primary hover:underline">Sign in</a>
+		</p>
+	</div>
+</div>

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -83,16 +83,17 @@
 					type="email"
 					placeholder="you@example.com"
 					bind:value={email}
+					variant={errors.email ? 'error' : 'default'}
 					autocomplete="email"
 					aria-describedby={errors.email ? 'email-error' : undefined}
-					disabled={isLoading}
+					disabled={isLoading || !!successMessage}
 				/>
 				{#if errors.email}
 					<p id="email-error" class="text-sm text-destructive">{errors.email}</p>
 				{/if}
 			</div>
 
-			<Button type="submit" class="w-full" disabled={isLoading}>
+			<Button type="submit" class="w-full" disabled={isLoading || !!successMessage}>
 				{#if isLoading}
 					Sending...
 				{:else}

--- a/web/src/routes/forgot-password/+page.ts
+++ b/web/src/routes/forgot-password/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -63,7 +63,7 @@
 	}
 
 	function handleForgotPassword() {
-		alert('Coming soon');
+		goto('/forgot-password');
 	}
 </script>
 

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/stores';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
@@ -12,6 +13,8 @@
 	let errors = $state<Record<string, string>>({});
 	let isLoading = $state(false);
 	let generalError = $state('');
+
+	const showResetSuccess = $derived($page.url.searchParams.get('reset') === 'success');
 
 	if (typeof window !== 'undefined' && localStorage.getItem('access_token')) {
 		goto('/');
@@ -77,6 +80,12 @@
 		{#if generalError}
 			<div class="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
 				{generalError}
+			</div>
+		{/if}
+
+		{#if showResetSuccess}
+			<div class="mb-4 rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400">
+				Password reset successful. You can now sign in with your new password.
 			</div>
 		{/if}
 

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -28,6 +28,12 @@
 			newErrors.password = 'Password is required';
 		} else if (password.length < 8) {
 			newErrors.password = 'Password must be at least 8 characters';
+		} else if (!/[A-Z]/.test(password)) {
+			newErrors.password = 'Password must contain at least 1 uppercase letter';
+		} else if (!/[a-z]/.test(password)) {
+			newErrors.password = 'Password must contain at least 1 lowercase letter';
+		} else if (!/[0-9]/.test(password)) {
+			newErrors.password = 'Password must contain at least 1 number';
 		}
 		if (password !== confirmPassword) {
 			newErrors.confirmPassword = 'Passwords do not match';


### PR DESCRIPTION
## Summary
- Add `/forgot-password` page with email input that calls `POST /api/auth/password/reset/request`
- Add `/auth/reset-password` page that reads token from URL and calls `POST /api/auth/password/reset/confirm`
- Update login page "Forgot password?" link to navigate to `/forgot-password` instead of showing alert

## Flow
1. Login → "Forgot password?" → `/forgot-password`
2. Enter email → backend sends reset link
3. Click email link → `/auth/reset-password?token=xxx`
4. Enter new password → reset confirmed → redirect to login