### PR TITLE
✨ feat: add email verification system with rate limiting

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/joho/godotenv"
 	"github.com/shuvo-paul/medminder/internal/common/config"
@@ -60,11 +63,21 @@ func main() {
 	}
 	defer dbConn.Close()
 
-	r, err := router.New(distFS, dbConn, cfg)
+	r, cleanup, err := router.New(distFS, dbConn, cfg)
 	if err != nil {
 		log.Error("failed to create router", log.F("error", err.Error()))
 		return
 	}
+	defer cleanup()
+
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		sig := <-sigCh
+		log.Info("shutting down server", log.F("signal", sig.String()))
+		cleanup()
+		os.Exit(0)
+	}()
 
 	log.Info("starting server", log.F("port", cfg.AppPort), log.F("env", cfg.AppEnv))
 	addr := fmt.Sprintf(":%d", cfg.AppPort)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -37,7 +37,7 @@ func testConfig() config.Config {
 }
 
 func TestHealthCheck_ReturnsOK(t *testing.T) {
-	r, err := router.New(testDistFS(), &sql.DB{}, testConfig())
+	r, _, err := router.New(testDistFS(), &sql.DB{}, testConfig())
 	require.NoError(t, err)
 	server := httptest.NewServer(r)
 	defer server.Close()
@@ -59,7 +59,7 @@ func TestHealthCheck_ReturnsOK(t *testing.T) {
 }
 
 func TestOpenAPISpec_IsServed(t *testing.T) {
-	r, err := router.New(testDistFS(), &sql.DB{}, testConfig())
+	r, _, err := router.New(testDistFS(), &sql.DB{}, testConfig())
 	require.NoError(t, err)
 	server := httptest.NewServer(r)
 	defer server.Close()

--- a/internal/common/email/queue.go
+++ b/internal/common/email/queue.go
@@ -1,0 +1,75 @@
+package email
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// EmailJob represents an email to be sent.
+type EmailJob struct {
+	To      string
+	Subject string
+	Body    string
+}
+
+// emailQueue manages the email sending queue.
+type emailQueue struct {
+	jobs    chan EmailJob
+	client  EmailClient
+	logger  *slog.Logger
+	workers int
+	wg      sync.WaitGroup
+}
+
+var (
+	globalQueue *emailQueue
+	queueOnce  sync.Once
+)
+
+// QueueEmail adds an email job to the queue.
+func QueueEmail(ctx context.Context, to, subject, body string) {
+	if globalQueue == nil {
+		return
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		globalQueue.jobs <- EmailJob{To: to, Subject: subject, Body: body}
+	}
+}
+
+// StartEmailQueue initializes the global email queue with worker pool.
+func StartEmailQueue(client EmailClient, workers int, logger *slog.Logger) {
+	queueOnce.Do(func() {
+		globalQueue = &emailQueue{
+			jobs:    make(chan EmailJob, 100),
+			client:  client,
+			logger:  logger,
+			workers: workers,
+		}
+		for i := 0; i < workers; i++ {
+			globalQueue.wg.Add(1)
+			go globalQueue.worker()
+		}
+	})
+}
+
+// StopEmailQueue gracefully shuts down the email queue.
+func StopEmailQueue() {
+	if globalQueue == nil {
+		return
+	}
+	close(globalQueue.jobs)
+	globalQueue.wg.Wait()
+}
+
+func (q *emailQueue) worker() {
+	defer q.wg.Done()
+	for job := range q.jobs {
+		ctx := context.Background()
+		if err := q.client.SendEmail(ctx, job.To, job.Subject, job.Body); err != nil {
+			q.logger.Error("failed to send email", "to", job.To, "subject", job.Subject, "error", err)
+		}
+	}
+}

--- a/internal/database/sqlc/queries/users.sql
+++ b/internal/database/sqlc/queries/users.sql
@@ -21,3 +21,6 @@ WHERE id = $1;
 UPDATE users
 SET password_hash = $2, updated_at = NOW()
 WHERE id = $1;
+
+-- name: VerifyUserEmail :exec
+UPDATE users SET email_verified = true, updated_at = NOW() WHERE id = $1;

--- a/internal/database/sqlc/users.sql.go
+++ b/internal/database/sqlc/users.sql.go
@@ -114,3 +114,12 @@ func (q *Queries) UpdateUserPassword(ctx context.Context, arg UpdateUserPassword
 	_, err := q.db.ExecContext(ctx, updateUserPassword, arg.ID, arg.PasswordHash)
 	return err
 }
+
+const verifyUserEmail = `-- name: VerifyUserEmail :exec
+UPDATE users SET email_verified = true, updated_at = NOW() WHERE id = $1
+`
+
+func (q *Queries) VerifyUserEmail(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, verifyUserEmail, id)
+	return err
+}

--- a/internal/features/auth/dto/auth.go
+++ b/internal/features/auth/dto/auth.go
@@ -40,8 +40,8 @@ type LoginOutput struct {
 }
 
 type LogoutInput struct {
-	Header struct {
-		Authorization string `header:"Authorization"`
+	Body struct {
+		Authorization string `json:"authorization"`
 	}
 }
 

--- a/internal/features/auth/dto/email_verification.go
+++ b/internal/features/auth/dto/email_verification.go
@@ -17,7 +17,7 @@ type VerifyEmailOutput struct {
 // ResendVerificationInput is the input for resending a verification email.
 type ResendVerificationInput struct {
 	Body struct {
-		Email string `json:"email" minLength:"1" maxLength:"255" pattern:"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"`
+		Authorization string `json:"authorization"`
 	}
 }
 

--- a/internal/features/auth/handlers/logout_test.go
+++ b/internal/features/auth/handlers/logout_test.go
@@ -25,8 +25,8 @@ func TestLogout_Successful(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `header:"Authorization"`
+	input := &dto.LogoutInput{Body: struct {
+		Authorization string `json:"authorization"`
 	}{Authorization: "Bearer " + token}}
 	_, err := handler(context.Background(), input)
 
@@ -40,8 +40,8 @@ func TestLogout_InvalidHeader(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `header:"Authorization"`
+	input := &dto.LogoutInput{Body: struct {
+		Authorization string `json:"authorization"`
 	}{Authorization: "Invalid"}}
 	_, err := handler(context.Background(), input)
 
@@ -59,8 +59,8 @@ func TestLogout_ExpiredToken(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `header:"Authorization"`
+	input := &dto.LogoutInput{Body: struct {
+		Authorization string `json:"authorization"`
 	}{Authorization: "Bearer " + token}}
 	_, err := handler(context.Background(), input)
 
@@ -79,8 +79,8 @@ func TestLogout_DBError(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `header:"Authorization"`
+	input := &dto.LogoutInput{Body: struct {
+		Authorization string `json:"authorization"`
 	}{Authorization: "Bearer " + token}}
 	_, err := handler(context.Background(), input)
 

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -60,3 +60,20 @@ func (m *MockTokenService) ValidateAccessToken(tokenString string) (jwt.MapClaim
 	}
 	return args.Get(0).(jwt.MapClaims), args.Error(1)
 }
+
+type MockEmailVerificationService struct {
+	mock.Mock
+}
+
+func (m *MockEmailVerificationService) VerifyEmail(ctx context.Context, token string) (*service.VerifyResult, error) {
+	args := m.Called(ctx, token)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*service.VerifyResult), args.Error(1)
+}
+
+func (m *MockEmailVerificationService) ResendVerification(ctx context.Context, userID uuid.UUID, email string) error {
+	args := m.Called(ctx, userID, email)
+	return args.Error(0)
+}

--- a/internal/features/auth/handlers/register.go
+++ b/internal/features/auth/handlers/register.go
@@ -9,7 +9,7 @@ import (
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 )
 
-func RegisterHandler(svc service.AuthService) func(context.Context, *dto.RegisterInput) (*dto.RegisterOutput, error) {
+func RegisterHandler(svc service.AuthService, emailSvc service.EmailVerificationService) func(context.Context, *dto.RegisterInput) (*dto.RegisterOutput, error) {
 	return func(ctx context.Context, input *dto.RegisterInput) (*dto.RegisterOutput, error) {
 		if err := ValidateEmail(input.Body.Email); err != nil {
 			return nil, huma.Error400BadRequest("Invalid email format", err)
@@ -28,6 +28,10 @@ func RegisterHandler(svc service.AuthService) func(context.Context, *dto.Registe
 			}
 			return nil, err
 		}
+
+		go func() {
+			emailSvc.ResendVerification(context.Background(), result.User.ID, result.User.Email)
+		}()
 
 		resp := &dto.RegisterOutput{}
 		resp.Body.User.ID = result.User.ID

--- a/internal/features/auth/handlers/register.go
+++ b/internal/features/auth/handlers/register.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/shuvo-paul/medminder/internal/common/log"
 	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 )
@@ -29,9 +30,15 @@ func RegisterHandler(svc service.AuthService, emailSvc service.EmailVerification
 			return nil, err
 		}
 
-		go func() {
-			emailSvc.ResendVerification(context.Background(), result.User.ID, result.User.Email)
-		}()
+go func() {
+		if err := emailSvc.ResendVerification(context.Background(), result.User.ID, result.User.Email); err != nil {
+			log.Error("failed to send verification email",
+				log.F("user_id", result.User.ID.String()),
+				log.F("email", result.User.Email),
+				log.F("error", err.Error()),
+			)
+		}
+	}()
 
 		resp := &dto.RegisterOutput{}
 		resp.Body.User.ID = result.User.ID

--- a/internal/features/auth/handlers/register_test.go
+++ b/internal/features/auth/handlers/register_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestRegister_Successful(t *testing.T) {
 	mockSvc := new(MockAuthService)
+	mockEmailSvc := new(MockEmailVerificationService)
 
 	userID := uuid.New()
 	email := "test@example.com"
@@ -33,8 +34,9 @@ func TestRegister_Successful(t *testing.T) {
 			EmailVerified: false,
 		},
 	}, nil)
+	mockEmailSvc.On("ResendVerification", mock.Anything, mock.Anything, email).Return(nil)
 
-	handler := handlers.RegisterHandler(mockSvc)
+	handler := handlers.RegisterHandler(mockSvc, mockEmailSvc)
 
 	input := &dto.RegisterInput{}
 	input.Body.Email = email
@@ -53,7 +55,8 @@ func TestRegister_Successful(t *testing.T) {
 
 func TestRegister_InvalidEmail(t *testing.T) {
 	mockSvc := new(MockAuthService)
-	handler := handlers.RegisterHandler(mockSvc)
+	mockEmailSvc := new(MockEmailVerificationService)
+	handler := handlers.RegisterHandler(mockSvc, mockEmailSvc)
 
 	input := &dto.RegisterInput{}
 	input.Body.Email = "invalid-email"
@@ -69,7 +72,8 @@ func TestRegister_InvalidEmail(t *testing.T) {
 
 func TestRegister_InvalidPassword(t *testing.T) {
 	mockSvc := new(MockAuthService)
-	handler := handlers.RegisterHandler(mockSvc)
+	mockEmailSvc := new(MockEmailVerificationService)
+	handler := handlers.RegisterHandler(mockSvc, mockEmailSvc)
 
 	input := &dto.RegisterInput{}
 	input.Body.Email = "test@example.com"
@@ -89,7 +93,8 @@ func TestRegister_EmailAlreadyExists(t *testing.T) {
 	mockSvc.On("Register", mock.Anything, "test@example.com", "Test User", "Password123").
 		Return(nil, service.ErrEmailExists)
 
-	handler := handlers.RegisterHandler(mockSvc)
+	mockEmailSvc := new(MockEmailVerificationService)
+	handler := handlers.RegisterHandler(mockSvc, mockEmailSvc)
 
 	input := &dto.RegisterInput{}
 	input.Body.Email = "test@example.com"

--- a/internal/features/auth/handlers/resend_verification.go
+++ b/internal/features/auth/handlers/resend_verification.go
@@ -10,10 +10,8 @@ import (
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 )
 
-// LogoutHandler returns a thin HTTP adapter that extracts the user ID from
-// the Authorization header and delegates logout to AuthService.
-func LogoutHandler(authSvc service.AuthService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.LogoutInput) (*dto.LogoutOutput, error) {
-	return func(ctx context.Context, input *dto.LogoutInput) (*dto.LogoutOutput, error) {
+func ResendVerificationHandler(svc service.EmailVerificationService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.ResendVerificationInput) (*dto.ResendVerificationOutput, error) {
+	return func(ctx context.Context, input *dto.ResendVerificationInput) (*dto.ResendVerificationOutput, error) {
 		authHeader := input.Body.Authorization
 		if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
 			return nil, huma.Error401Unauthorized("Invalid authorization header", nil)
@@ -39,15 +37,22 @@ func LogoutHandler(authSvc service.AuthService, tokenSvc service.TokenServiceInt
 			return nil, huma.Error401Unauthorized("Invalid user ID", nil)
 		}
 
-		if err := authSvc.Logout(ctx, userID); err != nil {
-			if errors.Is(err, service.ErrLogoutFailed) {
-				return nil, huma.Error500InternalServerError("Failed to logout", err)
+		email, ok := claims["email"].(string)
+		if !ok {
+			return nil, huma.Error401Unauthorized("Invalid email in token", nil)
+		}
+
+		if err := svc.ResendVerification(ctx, userID, email); err != nil {
+			if errors.Is(err, service.ErrRateLimitExceeded) {
+				return nil, huma.Error429TooManyRequests("Daily verification limit exceeded", err)
 			}
 			return nil, err
 		}
 
-		return &dto.LogoutOutput{Body: struct {
-			Message string `json:"message"`
-		}{Message: "logged out successfully"}}, nil
+		return &dto.ResendVerificationOutput{
+			Body: struct {
+				Message string `json:"message"`
+			}{Message: "Verification email sent"},
+		}, nil
 	}
 }

--- a/internal/features/auth/handlers/resend_verification_test.go
+++ b/internal/features/auth/handlers/resend_verification_test.go
@@ -1,0 +1,103 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
+	"github.com/shuvo-paul/medminder/internal/features/auth/handlers"
+	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestResendVerification_Successful(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+	mockTokenSvc := new(MockTokenService)
+
+	userID := uuid.New()
+	email := "test@example.com"
+	token := "valid-access-token"
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{
+		"sub":  userID.String(),
+		"email": email,
+	}, nil)
+	mockSvc.On("ResendVerification", mock.Anything, userID, email).Return(nil)
+
+	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
+
+	input := &dto.ResendVerificationInput{}
+	input.Body.Authorization = "Bearer " + token
+
+	resp, err := handler(context.Background(), input)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "Verification email sent", resp.Body.Message)
+	mockSvc.AssertExpectations(t)
+	mockTokenSvc.AssertExpectations(t)
+}
+
+func TestResendVerification_InvalidAuthHeader(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+	mockTokenSvc := new(MockTokenService)
+	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
+
+	input := &dto.ResendVerificationInput{}
+	input.Body.Authorization = "Invalid"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "Invalid authorization header")
+}
+
+func TestResendVerification_InvalidToken(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+	mockTokenSvc := new(MockTokenService)
+
+	mockTokenSvc.On("ValidateAccessToken", "invalid-token").Return(nil, service.ErrInvalidToken)
+
+	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
+
+	input := &dto.ResendVerificationInput{}
+	input.Body.Authorization = "Bearer invalid-token"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	mockTokenSvc.AssertExpectations(t)
+}
+
+func TestResendVerification_RateLimitExceeded(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+	mockTokenSvc := new(MockTokenService)
+
+	userID := uuid.New()
+	email := "test@example.com"
+	token := "valid-access-token"
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{
+		"sub":   userID.String(),
+		"email": email,
+	}, nil)
+	mockSvc.On("ResendVerification", mock.Anything, userID, email).Return(service.ErrRateLimitExceeded)
+
+	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
+
+	input := &dto.ResendVerificationInput{}
+	input.Body.Authorization = "Bearer " + token
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "Daily verification limit exceeded")
+	mockSvc.AssertExpectations(t)
+	mockTokenSvc.AssertExpectations(t)
+}

--- a/internal/features/auth/handlers/verify_email.go
+++ b/internal/features/auth/handlers/verify_email.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
+	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+)
+
+func VerifyEmailHandler(svc service.EmailVerificationService) func(context.Context, *dto.VerifyEmailInput) (*dto.VerifyEmailOutput, error) {
+	return func(ctx context.Context, input *dto.VerifyEmailInput) (*dto.VerifyEmailOutput, error) {
+		if input.Body.Token == "" {
+			return nil, huma.Error400BadRequest("Token is required", nil)
+		}
+
+		result, err := svc.VerifyEmail(ctx, input.Body.Token)
+		if err != nil {
+			if errors.Is(err, repository.ErrTokenNotFound) {
+				return nil, huma.Error400BadRequest("Invalid or expired token", err)
+			}
+			if errors.Is(err, repository.ErrTokenExpired) {
+				return nil, huma.Error400BadRequest("Invalid or expired token", err)
+			}
+			return nil, err
+		}
+
+		return &dto.VerifyEmailOutput{
+			Body: struct {
+				AccessToken string `json:"access_token"`
+			}{AccessToken: result.AccessToken},
+		}, nil
+	}
+}

--- a/internal/features/auth/handlers/verify_email_test.go
+++ b/internal/features/auth/handlers/verify_email_test.go
@@ -1,0 +1,83 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
+	"github.com/shuvo-paul/medminder/internal/features/auth/handlers"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
+	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestVerifyEmail_Successful(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+
+	accessToken := "new-access-token"
+
+	mockSvc.On("VerifyEmail", mock.Anything, "valid-token").Return(&service.VerifyResult{
+		AccessToken: accessToken,
+	}, nil)
+
+	handler := handlers.VerifyEmailHandler(mockSvc)
+
+	input := &dto.VerifyEmailInput{}
+	input.Body.Token = "valid-token"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, accessToken, resp.Body.AccessToken)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestVerifyEmail_EmptyToken(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+	handler := handlers.VerifyEmailHandler(mockSvc)
+
+	input := &dto.VerifyEmailInput{}
+	input.Body.Token = ""
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "Token is required")
+}
+
+func TestVerifyEmail_InvalidToken(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+
+	mockSvc.On("VerifyEmail", mock.Anything, "invalid-token").Return(nil, repository.ErrTokenNotFound)
+
+	handler := handlers.VerifyEmailHandler(mockSvc)
+
+	input := &dto.VerifyEmailInput{}
+	input.Body.Token = "invalid-token"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestVerifyEmail_ExpiredToken(t *testing.T) {
+	mockSvc := new(MockEmailVerificationService)
+
+	mockSvc.On("VerifyEmail", mock.Anything, "expired-token").Return(nil, repository.ErrTokenExpired)
+
+	handler := handlers.VerifyEmailHandler(mockSvc)
+
+	input := &dto.VerifyEmailInput{}
+	input.Body.Token = "expired-token"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	mockSvc.AssertExpectations(t)
+}

--- a/internal/features/auth/repository/errors.go
+++ b/internal/features/auth/repository/errors.go
@@ -1,0 +1,9 @@
+package repository
+
+import "errors"
+
+var (
+	ErrTokenNotFound = errors.New("token not found")
+	ErrTokenExpired  = errors.New("token expired")
+	ErrTokenUsed     = errors.New("token already used")
+)

--- a/internal/features/auth/repository/password_reset_token_repository.go
+++ b/internal/features/auth/repository/password_reset_token_repository.go
@@ -10,12 +10,6 @@ import (
 	"github.com/shuvo-paul/medminder/internal/database/sqlc"
 )
 
-var (
-	ErrTokenNotFound = errors.New("token not found")
-	ErrTokenExpired  = errors.New("token expired")
-	ErrTokenUsed     = errors.New("token already used")
-)
-
 type PasswordResetTokenRepository interface {
 	CreateToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.PasswordResetToken, error)
 	FindValidToken(ctx context.Context, tokenHash string) (db.PasswordResetToken, error)

--- a/internal/features/auth/repository/user_repository.go
+++ b/internal/features/auth/repository/user_repository.go
@@ -13,6 +13,7 @@ type UserRepository interface {
 	GetUserByEmail(ctx context.Context, email string) (db.User, error)
 	GetUserByID(ctx context.Context, id string) (db.User, error)
 	UpdatePassword(ctx context.Context, id, passwordHash string) error
+	VerifyEmail(ctx context.Context, id uuid.UUID) error
 }
 
 type userRepository struct {
@@ -45,4 +46,8 @@ func (r *userRepository) UpdatePassword(ctx context.Context, id, passwordHash st
 		ID:           uuid.MustParse(id),
 		PasswordHash: sql.NullString{String: passwordHash, Valid: true},
 	})
+}
+
+func (r *userRepository) VerifyEmail(ctx context.Context, id uuid.UUID) error {
+	return r.queries.VerifyUserEmail(ctx, id)
 }

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -16,10 +16,12 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string, emailCl
 	// Repos (used to construct services)
 	userRepo := repository.NewUserRepository(queries)
 	tokenRepo := repository.NewRefreshTokenRepository(queries)
+	evTokenRepo := repository.NewEmailVerificationTokenRepository(queries)
 	tokenSvc := service.NewTokenService(jwtSecret)
 
 	// Services
 	authSvc := service.NewAuthService(userRepo, tokenRepo, tokenSvc)
+	emailVerifSvc := service.NewEmailVerificationService(userRepo, evTokenRepo, tokenSvc, frontendURL)
 	passwordResetSvc := service.NewPasswordResetService(
 		userRepo,
 		repository.NewPasswordResetTokenRepository(queries),
@@ -28,14 +30,14 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string, emailCl
 		frontendURL,
 	)
 
-	// Register
+	// Register (with email verification)
 	huma.Register(api, huma.Operation{
 		OperationID: "register-user",
 		Method:      http.MethodPost,
 		Path:        "/api/auth/register",
 		Summary:     "Register a new user",
 		Tags:        []string{"auth"},
-	}, handlers.RegisterHandler(authSvc))
+	}, handlers.RegisterHandler(authSvc, emailVerifSvc))
 
 	// Login
 	huma.Register(api, huma.Operation{
@@ -54,6 +56,24 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string, emailCl
 		Summary:     "Logout user",
 		Tags:        []string{"auth"},
 	}, handlers.LogoutHandler(authSvc, tokenSvc))
+
+	// Email verification (unauthenticated)
+	huma.Register(api, huma.Operation{
+		OperationID: "verify-email",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/email/verify",
+		Summary:     "Verify email address",
+		Tags:        []string{"auth"},
+	}, handlers.VerifyEmailHandler(emailVerifSvc))
+
+	// Resend verification (authenticated)
+	huma.Register(api, huma.Operation{
+		OperationID: "resend-verification",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/email/resend-verification",
+		Summary:     "Resend verification email",
+		Tags:        []string{"auth"},
+	}, handlers.ResendVerificationHandler(emailVerifSvc, tokenSvc))
 
 	// Password reset routes (already use dto types)
 	passwordResetDeps := handlers.NewPasswordResetDeps(passwordResetSvc)

--- a/internal/features/auth/service/auth_service_test.go
+++ b/internal/features/auth/service/auth_service_test.go
@@ -44,6 +44,11 @@ func (m *MockUserRepository) UpdatePassword(ctx context.Context, id, passwordHas
 	return args.Error(0)
 }
 
+func (m *MockUserRepository) VerifyEmail(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 // MockRefreshTokenRepository mocks repository.RefreshTokenRepository
 type MockRefreshTokenRepository struct {
 	mock.Mock

--- a/internal/features/auth/service/email_verification_service.go
+++ b/internal/features/auth/service/email_verification_service.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	emailqueue "github.com/shuvo-paul/medminder/internal/common/email"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
+)
+
+const (
+	emailVerificationTokenExpiry = 24 * time.Hour
+	maxVerificationsPerDay      = 3
+	verificationTokenByteSize   = 32
+)
+
+type VerifyResult struct {
+	AccessToken string
+	User        struct {
+		ID            uuid.UUID
+		Email         string
+		DisplayName   string
+		EmailVerified bool
+	}
+}
+
+// EmailVerificationService defines the interface for email verification operations.
+type EmailVerificationService interface {
+	VerifyEmail(ctx context.Context, token string) (*VerifyResult, error)
+	ResendVerification(ctx context.Context, userID uuid.UUID, email string) error
+}
+
+// emailVerificationService implements EmailVerificationService.
+type emailVerificationService struct {
+	userRepo         repository.UserRepository
+	tokenRepo        repository.EmailVerificationTokenRepository
+	tokenSvc         TokenServiceInterface
+	frontendURL      string
+}
+
+// NewEmailVerificationService creates a new EmailVerificationService.
+func NewEmailVerificationService(
+	userRepo repository.UserRepository,
+	tokenRepo repository.EmailVerificationTokenRepository,
+	tokenSvc TokenServiceInterface,
+	frontendURL string,
+) *emailVerificationService {
+	return &emailVerificationService{
+		userRepo:    userRepo,
+		tokenRepo:   tokenRepo,
+		tokenSvc:    tokenSvc,
+		frontendURL: frontendURL,
+	}
+}
+
+// VerifyEmail validates a verification token and marks the user's email as verified.
+// It returns a new access token upon successful verification.
+func (s *emailVerificationService) VerifyEmail(ctx context.Context, token string) (*VerifyResult, error) {
+	tokenHash, err := hashEmailVerificationToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("hashing token: %w", err)
+	}
+
+	storedToken, err := s.tokenRepo.FindValidToken(ctx, tokenHash)
+	if err != nil {
+		if errors.Is(err, repository.ErrTokenNotFound) || errors.Is(err, repository.ErrTokenExpired) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("finding valid token: %w", err)
+	}
+
+	user, err := s.userRepo.GetUserByID(ctx, storedToken.UserID.String())
+	if err != nil {
+		return nil, fmt.Errorf("getting user: %w", err)
+	}
+
+	if err := s.userRepo.VerifyEmail(ctx, user.ID); err != nil {
+		return nil, fmt.Errorf("verifying email: %w", err)
+	}
+
+	if err := s.tokenRepo.DeleteToken(ctx, storedToken.ID); err != nil {
+		fmt.Printf("warning: failed to delete used token: %v\n", err)
+	}
+	if err := s.tokenRepo.DeleteAllForUser(ctx, user.ID); err != nil {
+		fmt.Printf("warning: failed to delete user tokens: %v\n", err)
+	}
+
+	accessToken, err := s.tokenSvc.GenerateAccessToken(user.ID, user.Email)
+	if err != nil {
+		return nil, fmt.Errorf("generating access token: %w", err)
+	}
+
+	result := &VerifyResult{}
+	result.AccessToken = accessToken
+	result.User.ID = user.ID
+	result.User.Email = user.Email
+	result.User.DisplayName = user.DisplayName
+	result.User.EmailVerified = true
+
+	return result, nil
+}
+
+// ResendVerification sends a new verification email if the daily limit hasn't been exceeded.
+func (s *emailVerificationService) ResendVerification(ctx context.Context, userID uuid.UUID, email string) error {
+	count, err := s.tokenRepo.CountTokensCreatedToday(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("checking token count: %w", err)
+	}
+
+	if count >= maxVerificationsPerDay {
+		return ErrRateLimitExceeded
+	}
+
+	tokenBytes := make([]byte, verificationTokenByteSize)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		return fmt.Errorf("generating token: %w", err)
+	}
+	rawToken := hex.EncodeToString(tokenBytes)
+
+	tokenHash, err := hashToken(rawToken)
+	if err != nil {
+		return fmt.Errorf("hashing token: %w", err)
+	}
+
+	expiresAt := time.Now().Add(emailVerificationTokenExpiry)
+
+	_, err = s.tokenRepo.CreateToken(ctx, uuid.New(), userID, tokenHash, expiresAt)
+	if err != nil {
+		return fmt.Errorf("storing token: %w", err)
+	}
+
+	verificationLink := fmt.Sprintf("%s/auth/verify-email?token=%s", s.frontendURL, rawToken)
+	emailBody := fmt.Sprintf("<p>Click <a href=\"%s\">here</a> to verify your email address.</p>", verificationLink)
+
+	emailqueue.QueueEmail(ctx, email, "MedMinder Email Verification", emailBody)
+
+	return nil
+}
+
+// hashEmailVerificationToken hashes a token using SHA256.
+func hashEmailVerificationToken(token string) (string, error) {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:]), nil
+}

--- a/internal/features/auth/service/email_verification_service.go
+++ b/internal/features/auth/service/email_verification_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	emailqueue "github.com/shuvo-paul/medminder/internal/common/email"
+	"github.com/shuvo-paul/medminder/internal/common/log"
 	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
 )
 
@@ -86,10 +87,10 @@ func (s *emailVerificationService) VerifyEmail(ctx context.Context, token string
 	}
 
 	if err := s.tokenRepo.DeleteToken(ctx, storedToken.ID); err != nil {
-		fmt.Printf("warning: failed to delete used token: %v\n", err)
+		log.Warn("failed to delete used token", log.F("token_id", storedToken.ID.String()), log.F("error", err.Error()))
 	}
 	if err := s.tokenRepo.DeleteAllForUser(ctx, user.ID); err != nil {
-		fmt.Printf("warning: failed to delete user tokens: %v\n", err)
+		log.Warn("failed to delete user tokens", log.F("user_id", user.ID.String()), log.F("error", err.Error()))
 	}
 
 	accessToken, err := s.tokenSvc.GenerateAccessToken(user.ID, user.Email)
@@ -124,7 +125,7 @@ func (s *emailVerificationService) ResendVerification(ctx context.Context, userI
 	}
 	rawToken := hex.EncodeToString(tokenBytes)
 
-	tokenHash, err := hashToken(rawToken)
+	tokenHash, err := hashEmailVerificationToken(rawToken)
 	if err != nil {
 		return fmt.Errorf("hashing token: %w", err)
 	}

--- a/internal/features/auth/service/errors.go
+++ b/internal/features/auth/service/errors.go
@@ -14,4 +14,6 @@ var (
 	ErrEmailExists        = errors.New("email already exists")
 	ErrInvalidCredentials = errors.New("invalid credentials")
 	ErrLogoutFailed       = errors.New("logout failed")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
+	ErrEmailNotFound      = errors.New("email not found")
 )

--- a/internal/features/auth/service/password_reset_service_test.go
+++ b/internal/features/auth/service/password_reset_service_test.go
@@ -21,6 +21,7 @@ type MockPRUserRepository struct {
 	GetUserByIDFn    func(ctx context.Context, id string) (db.User, error)
 	UpdatePasswordFn func(ctx context.Context, id, passwordHash string) error
 	CreateUserFn     func(ctx context.Context, email, displayName, passwordHash string) (db.CreateUserRow, error)
+	VerifyEmailFn     func(ctx context.Context, id uuid.UUID) error
 }
 
 func (m *MockPRUserRepository) CreateUser(ctx context.Context, email, displayName, passwordHash string) (db.CreateUserRow, error) {
@@ -47,6 +48,13 @@ func (m *MockPRUserRepository) GetUserByID(ctx context.Context, id string) (db.U
 func (m *MockPRUserRepository) UpdatePassword(ctx context.Context, id, passwordHash string) error {
 	if m.UpdatePasswordFn != nil {
 		return m.UpdatePasswordFn(ctx, id, passwordHash)
+	}
+	return nil
+}
+
+func (m *MockPRUserRepository) VerifyEmail(ctx context.Context, id uuid.UUID) error {
+	if m.VerifyEmailFn != nil {
+		return m.VerifyEmailFn(ctx, id)
 	}
 	return nil
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -15,7 +15,7 @@ import (
 	"github.com/shuvo-paul/medminder/internal/features/auth"
 )
 
-func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, error) {
+func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, func(), error) {
 	router := chi.NewRouter()
 
 	api := setupHuma(router)
@@ -36,7 +36,11 @@ func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, error) 
 
 	router.Handle("/*", newSPAHandler(distFS))
 
-	return router, nil
+	cleanup := func() {
+		email.StopEmailQueue()
+	}
+
+	return router, cleanup, nil
 }
 
 func setupHuma(router *chi.Mux) huma.API {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -23,6 +23,7 @@ func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, error) 
 	queries := db.New(dbConn)
 
 	emailClient := email.NewEmailClient(cfg.Email)
+	email.StartEmailQueue(emailClient, 3, nil)
 
 	auth.RegisterRoutes(api, queries, cfg.JWT.Secret, emailClient, cfg.FrontendURL)
 


### PR DESCRIPTION
## Summary
- Add background email queue worker pool for async email sending
- Add email verification token repository and service
- Add two API endpoints: verify email and resend verification
- Resend verification rate limited to 3 per day
- Integrate with registration to auto-send verification email

Close #57 