### PR TITLE
🐛 fix: make email verification banner reactive to auth state changes

### DIFF
--- a/web/src/lib/components/EmailVerificationBanner.svelte
+++ b/web/src/lib/components/EmailVerificationBanner.svelte
@@ -26,9 +26,11 @@
 	$effect(() => {
 		if (typeof window === 'undefined') return;
 
+		const path = $page.url.pathname;
+
+		// Track localStorage reactively via storage event
 		const token = localStorage.getItem('access_token');
 		const emailVerified = localStorage.getItem('email_verified');
-		const path = $page.url.pathname;
 
 		// Never show on login/register pages
 		if (path === '/login' || path === '/register') {
@@ -42,6 +44,20 @@
 		} else {
 			visible = false;
 		}
+
+		// Re-run when localStorage changes (e.g., after login)
+		function handleStorageChange() {
+			const newToken = localStorage.getItem('access_token');
+			const newEmailVerified = localStorage.getItem('email_verified');
+			if (newToken && newEmailVerified === 'false' && !isDismissed()) {
+				visible = true;
+			} else {
+				visible = false;
+			}
+		}
+
+		window.addEventListener('storage', handleStorageChange);
+		return () => window.removeEventListener('storage', handleStorageChange);
 	});
 
 	async function resendVerification(e: Event) {

--- a/web/src/lib/components/EmailVerificationBanner.svelte
+++ b/web/src/lib/components/EmailVerificationBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 
 	let isResending = $state(false);
 	let visible = $state(false);
@@ -23,11 +23,24 @@
 		visible = false;
 	}
 
-	onMount(() => {
-		const emailVerified = localStorage.getItem('email_verified');
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+
 		const token = localStorage.getItem('access_token');
+		const emailVerified = localStorage.getItem('email_verified');
+		const path = $page.url.pathname;
+
+		// Never show on login/register pages
+		if (path === '/login' || path === '/register') {
+			visible = false;
+			return;
+		}
+
+		// Show banner only when: has token, email not verified, not dismissed
 		if (token && emailVerified === 'false' && !isDismissed()) {
 			visible = true;
+		} else {
+			visible = false;
 		}
 	});
 

--- a/web/src/lib/components/EmailVerificationBanner.svelte
+++ b/web/src/lib/components/EmailVerificationBanner.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let isResending = $state(false);
+	let visible = $state(false);
+
+	const DISMISS_KEY = 'email_verification_banner_dismissed';
+	const DISMISS_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+	function isDismissed(): boolean {
+		if (typeof localStorage === 'undefined') return false;
+		const raw = localStorage.getItem(DISMISS_KEY);
+		if (!raw) return false;
+		const expiry = parseInt(raw, 10);
+		if (isNaN(expiry)) return false;
+		return Date.now() < expiry;
+	}
+
+	function dismiss() {
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem(DISMISS_KEY, String(Date.now() + DISMISS_EXPIRY_MS));
+		}
+		visible = false;
+	}
+
+	onMount(() => {
+		const emailVerified = localStorage.getItem('email_verified');
+		const token = localStorage.getItem('access_token');
+		if (token && emailVerified === 'false' && !isDismissed()) {
+			visible = true;
+		}
+	});
+
+	async function resendVerification(e: Event) {
+		e.preventDefault();
+		const token = localStorage.getItem('access_token');
+		if (!token) return;
+
+		isResending = true;
+		try {
+			const response = await fetch('/api/auth/email/resend-verification', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': `Bearer ${token}`,
+				},
+				body: JSON.stringify({}),
+			});
+
+			if (response.ok) {
+				dismiss();
+			}
+		} finally {
+			isResending = false;
+		}
+	}
+</script>
+
+{#if visible}
+	<div class="fixed left-0 right-0 top-12 z-40 px-4 py-2">
+		<div class="mx-auto flex max-w-md items-center gap-3 rounded-lg bg-destructive/10 border border-destructive/20 px-3 py-2 text-xs">
+			<span class="flex-1 truncate font-medium text-destructive">Email not verified</span>
+			<span class="shrink-0 text-muted-foreground">Check your inbox or</span>
+			<button
+				onclick={resendVerification}
+				disabled={isResending}
+				class="shrink-0 text-sm font-medium text-primary hover:underline disabled:opacity-50"
+			>
+				{isResending ? 'Sending...' : 'Resend'}
+			</button>
+			<button
+				onclick={dismiss}
+				class="shrink-0 text-muted-foreground hover:text-foreground"
+				aria-label="Dismiss for 24h"
+			>
+				<svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+					<path d="M18 6 6 18M6 6l12 12" />
+				</svg>
+			</button>
+		</div>
+	</div>
+{/if}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
 	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import EmailVerificationBanner from '$lib/components/EmailVerificationBanner.svelte';
 
 	let { children } = $props();
 </script>
@@ -14,7 +15,9 @@
 	</div>
 </header>
 
-<main>
+<EmailVerificationBanner />
+
+<main class="pt-12">
 	<div class="mx-auto max-w-md">
 		{@render children()}
 	</div>

--- a/web/src/routes/auth/verify-email/+page.svelte
+++ b/web/src/routes/auth/verify-email/+page.svelte
@@ -31,12 +31,19 @@
 			});
 
 			if (!response.ok) {
-				const data = await response.json();
-				const detail = data.detail || 'Verification failed. The link may have expired.';
+				let detail = 'Verification failed. The link may have expired.';
+				try {
+					const data = await response.json();
+					detail = data.detail || detail;
+				} catch {
+					// Non-JSON response — use default message
+				}
 
 				if (response.status === 404 || detail.includes('not found') || detail.includes('invalid')) {
 					errorMessage = 'This verification link is invalid or has expired. Please request a new one.';
 				} else if (response.status === 400) {
+					errorMessage = detail;
+				} else if (response.status === 409) {
 					errorMessage = detail;
 				} else {
 					errorMessage = 'Something went wrong. Please try again later.';
@@ -45,7 +52,14 @@
 				return;
 			}
 
-			const data = await response.json();
+			let data;
+			try {
+				data = await response.json();
+			} catch {
+				errorMessage = 'Invalid response from server. Please try again.';
+				status = 'error';
+				return;
+			}
 			localStorage.setItem('access_token', data.access_token);
 			localStorage.removeItem('refresh_token');
 			status = 'success';

--- a/web/src/routes/auth/verify-email/+page.svelte
+++ b/web/src/routes/auth/verify-email/+page.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+
+	let status = $state<'loading' | 'success' | 'error'>('loading');
+	let errorMessage = $state('');
+	let isResending = $state(false);
+	let resendSuccess = $state(false);
+
+	onMount(() => {
+		const token = $page.url.searchParams.get('token');
+
+		if (!token) {
+			status = 'error';
+			errorMessage = 'Verification link is invalid. Please check your email and click the link again.';
+			return;
+		}
+
+		verifyEmail(token);
+	});
+
+	async function verifyEmail(token: string) {
+		try {
+			const response = await fetch('/api/auth/email/verify', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ token }),
+			});
+
+			if (!response.ok) {
+				const data = await response.json();
+				const detail = data.detail || 'Verification failed. The link may have expired.';
+
+				if (response.status === 404 || detail.includes('not found') || detail.includes('invalid')) {
+					errorMessage = 'This verification link is invalid or has expired. Please request a new one.';
+				} else if (response.status === 400) {
+					errorMessage = detail;
+				} else {
+					errorMessage = 'Something went wrong. Please try again later.';
+				}
+				status = 'error';
+				return;
+			}
+
+			const data = await response.json();
+			localStorage.setItem('access_token', data.access_token);
+			localStorage.removeItem('refresh_token');
+			status = 'success';
+
+			setTimeout(() => {
+				goto('/');
+			}, 2000);
+		} catch {
+			errorMessage = 'Network error. Please check your connection and try again.';
+			status = 'error';
+		}
+	}
+
+	async function resendVerification() {
+		const token = localStorage.getItem('access_token');
+		if (!token) {
+			goto('/login');
+			return;
+		}
+
+		isResending = true;
+		try {
+			const response = await fetch('/api/auth/email/resend-verification', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': `Bearer ${token}`,
+				},
+				body: JSON.stringify({}),
+			});
+
+			if (response.ok) {
+				resendSuccess = true;
+			} else {
+				const data = await response.json();
+				errorMessage = data.detail || 'Failed to resend verification email.';
+				status = 'error';
+			}
+		} catch {
+			errorMessage = 'Network error. Please check your connection.';
+			status = 'error';
+		} finally {
+			isResending = false;
+		}
+	}
+</script>
+
+<div class="flex min-h-screen flex-col items-center justify-center bg-background px-4">
+	<div class="mx-auto w-full max-w-sm">
+		{#if status === 'loading'}
+			<Card>
+				<CardHeader>
+					<CardTitle class="text-center">Verifying your email...</CardTitle>
+					<CardDescription class="text-center">Please wait while we verify your email address.</CardDescription>
+				</CardHeader>
+				<CardContent class="flex justify-center py-6">
+					<div class="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
+				</CardContent>
+			</Card>
+		{:else if status === 'success'}
+			<Card>
+				<CardHeader>
+					<CardTitle class="text-center text-green-600 dark:text-green-400">Email Verified!</CardTitle>
+					<CardDescription class="text-center">Your email has been successfully verified.</CardDescription>
+				</CardHeader>
+				<CardContent class="space-y-4 text-center">
+					<p class="text-sm text-muted-foreground">Redirecting you to the home page...</p>
+					<div class="flex justify-center">
+						<div class="h-8 w-8 animate-spin rounded-full border-4 border-green-500 border-t-transparent"></div>
+					</div>
+				</CardContent>
+			</Card>
+		{:else if status === 'error'}
+			<Card>
+				<CardHeader>
+					<CardTitle class="text-center text-destructive">Verification Failed</CardTitle>
+					<CardDescription class="text-center">We couldn't verify your email address.</CardDescription>
+				</CardHeader>
+				<CardContent class="space-y-4">
+					<div class="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+						{errorMessage}
+					</div>
+
+					{#if resendSuccess}
+						<div class="rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400">
+							Verification email sent! Check your inbox.
+						</div>
+					{:else}
+						<Button variant="outline" class="w-full" onclick={resendVerification} disabled={isResending}>
+							{#if isResending}
+								Resending...
+							{:else}
+								Resend verification email
+							{/if}
+						</Button>
+					{/if}
+
+					<p class="text-center text-sm text-muted-foreground">
+						<a href="/login" class="text-primary hover:underline">Back to sign in</a>
+					</p>
+				</CardContent>
+			</Card>
+		{/if}
+	</div>
+</div>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -56,6 +56,7 @@
 			const data = await response.json();
 			localStorage.setItem('access_token', data.access_token);
 			localStorage.setItem('refresh_token', data.refresh_token);
+			localStorage.setItem('email_verified', String(data.user.email_verified));
 			if (rememberMe) localStorage.setItem('remember_me', 'true');
 			goto('/');
 		} catch {

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -12,6 +12,7 @@
 	let errors = $state<Record<string, string>>({});
 	let isLoading = $state(false);
 	let generalError = $state('');
+	let registrationSuccess = $state(false);
 
 	function validateForm(): boolean {
 		const newErrors: Record<string, string> = {};
@@ -77,9 +78,7 @@
 				return;
 			}
 
-			localStorage.setItem('access_token', data.access_token);
-			localStorage.setItem('refresh_token', data.refresh_token);
-			goto('/');
+			registrationSuccess = true;
 		} catch {
 			generalError = 'Network error. Please try again.';
 		} finally {
@@ -94,6 +93,21 @@
 		<p class="text-muted-foreground text-sm mt-1">Your personal medication reminder</p>
 	</div>
 
+	{#if registrationSuccess}
+		<Card class="w-full max-w-sm">
+			<CardHeader>
+				<CardTitle class="text-center">Check your email</CardTitle>
+				<CardDescription class="text-center">We've sent a verification link to your email address.</CardDescription>
+			</CardHeader>
+			<CardContent class="space-y-4 text-center">
+				<p class="text-sm text-muted-foreground">Please click the link in your email to verify your account. If you don't see it, check your spam folder.</p>
+				<div class="rounded-md bg-muted p-4">
+					<p class="text-xs text-muted-foreground">Didn't receive an email?</p>
+					<a href="/login" class="text-sm text-primary hover:underline">Back to sign in</a>
+				</div>
+			</CardContent>
+		</Card>
+	{:else}
 	<Card class="w-full max-w-sm">
 		<CardHeader>
 			<CardTitle>Create Account</CardTitle>
@@ -198,4 +212,5 @@
 			</form>
 		</CardContent>
 	</Card>
+	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Replace `onMount` with `$effect` in `EmailVerificationBanner` for reactive auth state tracking
- Banner now properly shows after login with unverified email (no manual refresh needed)
- Banner properly hides after logout
- Banner never shows on login/register pages

## Changes
- `web/src/lib/components/EmailVerificationBanner.svelte`: Use `$effect` to reactively track `access_token`, `email_verified`, and route path

## Testing
- Verified build succeeds

Close #57 