### PR TITLE
🐛 fix: move authorization from request body to header

### DIFF
--- a/.opencode/context/development/principles/api-design.md
+++ b/.opencode/context/development/principles/api-design.md
@@ -343,6 +343,7 @@ Link: <https://api.example.com/v2/users>; rel="successor-version"
 
 // Middleware
 function authenticateToken(req, res, next) {
+  // ✅ Always extract token from Authorization header
   const token = req.headers.authorization?.split(' ')[1];
   
   if (!token) {
@@ -408,6 +409,7 @@ app.delete('/users/:id',
 - ❌ **No rate limiting** - Protect against abuse
 - ❌ **Verbose error messages** - Don't leak implementation details
 - ❌ **Synchronous long operations** - Use async jobs for long tasks
+- ❌ **Authorization tokens in request body** - Always use `Authorization: Bearer <token>` header; never pass auth tokens in the request body
 
 ## References
 

--- a/.opencode/context/project-intelligence/technical-domain.md
+++ b/.opencode/context/project-intelligence/technical-domain.md
@@ -85,8 +85,24 @@ repository/→ Data access: sqlc queries, CRUD. No business logic.
 ### huma v2 API Handler + DTO Pattern
 ```go
 // dto/auth.go — wire format + validation tags owned by dto package
+// Body input (request body):
 // type RegisterInput struct { Body struct { Email string `json:"email" ...` } }
-// type RegisterOutput struct { Body struct { User User `json:"user"` } }
+
+// Header input (request headers) — idiomatic huma pattern:
+// type LogoutInput struct { Authorization string `header:"Authorization" json:"-"` }
+
+type RegisterInput struct {
+	Body struct {
+		Email       string `json:"email" minLength:"1" maxLength:"255" pattern:"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2}$"`
+		DisplayName string `json:"display_name" minLength:"1" maxLength:"100"`
+		Password    string `json:"password" minLength:"8"`
+	}
+}
+
+// For header-based auth inputs, use direct field with header tag:
+type LogoutInput struct {
+	Authorization string `header:"Authorization" json:"-"`
+}
 
 // handlers/register.go — thin HTTP adapter (error translation lives here)
 func RegisterHandler(svc service.AuthService) func(context.Context, *dto.RegisterInput) (*dto.RegisterOutput, error) {

--- a/internal/features/auth/dto/auth.go
+++ b/internal/features/auth/dto/auth.go
@@ -40,8 +40,8 @@ type LoginOutput struct {
 }
 
 type LogoutInput struct {
-	Body struct {
-		Authorization string `json:"authorization"`
+	Header struct {
+		Authorization string `json:"-"`
 	}
 }
 

--- a/internal/features/auth/dto/auth.go
+++ b/internal/features/auth/dto/auth.go
@@ -40,9 +40,7 @@ type LoginOutput struct {
 }
 
 type LogoutInput struct {
-	Header struct {
-		Authorization string `json:"-"`
-	}
+	Authorization string `header:"Authorization" json:"-"`
 }
 
 type LogoutOutput struct {

--- a/internal/features/auth/dto/email_verification.go
+++ b/internal/features/auth/dto/email_verification.go
@@ -16,12 +16,9 @@ type VerifyEmailOutput struct {
 
 // ResendVerificationInput is the input for resending a verification email.
 type ResendVerificationInput struct {
-	Header struct {
-		Authorization string `json:"-"`
-	}
+	Authorization string `header:"Authorization" json:"-"`
 }
 
-// ResendVerificationOutput is the output after requesting a verification email resend.
 type ResendVerificationOutput struct {
 	Body struct {
 		Message string `json:"message"`

--- a/internal/features/auth/dto/email_verification.go
+++ b/internal/features/auth/dto/email_verification.go
@@ -16,8 +16,8 @@ type VerifyEmailOutput struct {
 
 // ResendVerificationInput is the input for resending a verification email.
 type ResendVerificationInput struct {
-	Body struct {
-		Authorization string `json:"authorization"`
+	Header struct {
+		Authorization string `json:"-"`
 	}
 }
 

--- a/internal/features/auth/handlers/logout.go
+++ b/internal/features/auth/handlers/logout.go
@@ -14,7 +14,7 @@ import (
 // the Authorization header and delegates logout to AuthService.
 func LogoutHandler(authSvc service.AuthService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.LogoutInput) (*dto.LogoutOutput, error) {
 	return func(ctx context.Context, input *dto.LogoutInput) (*dto.LogoutOutput, error) {
-		authHeader := input.Body.Authorization
+		authHeader := input.Header.Authorization
 		if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
 			return nil, huma.Error401Unauthorized("Invalid authorization header", nil)
 		}

--- a/internal/features/auth/handlers/logout.go
+++ b/internal/features/auth/handlers/logout.go
@@ -14,7 +14,7 @@ import (
 // the Authorization header and delegates logout to AuthService.
 func LogoutHandler(authSvc service.AuthService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.LogoutInput) (*dto.LogoutOutput, error) {
 	return func(ctx context.Context, input *dto.LogoutInput) (*dto.LogoutOutput, error) {
-		authHeader := input.Header.Authorization
+		authHeader := input.Authorization
 		if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
 			return nil, huma.Error401Unauthorized("Invalid authorization header", nil)
 		}

--- a/internal/features/auth/handlers/logout_test.go
+++ b/internal/features/auth/handlers/logout_test.go
@@ -25,8 +25,8 @@ func TestLogout_Successful(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Body: struct {
-		Authorization string `json:"authorization"`
+	input := &dto.LogoutInput{Header: struct {
+		Authorization string `json:"-"`
 	}{Authorization: "Bearer " + token}}
 	_, err := handler(context.Background(), input)
 
@@ -40,8 +40,8 @@ func TestLogout_InvalidHeader(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Body: struct {
-		Authorization string `json:"authorization"`
+	input := &dto.LogoutInput{Header: struct {
+		Authorization string `json:"-"`
 	}{Authorization: "Invalid"}}
 	_, err := handler(context.Background(), input)
 
@@ -59,8 +59,8 @@ func TestLogout_ExpiredToken(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Body: struct {
-		Authorization string `json:"authorization"`
+	input := &dto.LogoutInput{Header: struct {
+		Authorization string `json:"-"`
 	}{Authorization: "Bearer " + token}}
 	_, err := handler(context.Background(), input)
 
@@ -79,8 +79,8 @@ func TestLogout_DBError(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Body: struct {
-		Authorization string `json:"authorization"`
+	input := &dto.LogoutInput{Header: struct {
+		Authorization string `json:"-"`
 	}{Authorization: "Bearer " + token}}
 	_, err := handler(context.Background(), input)
 

--- a/internal/features/auth/handlers/logout_test.go
+++ b/internal/features/auth/handlers/logout_test.go
@@ -25,9 +25,7 @@ func TestLogout_Successful(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `json:"-"`
-	}{Authorization: "Bearer " + token}}
+	input := &dto.LogoutInput{Authorization: "Bearer " + token}
 	_, err := handler(context.Background(), input)
 
 	assert.NoError(t, err)
@@ -40,9 +38,7 @@ func TestLogout_InvalidHeader(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `json:"-"`
-	}{Authorization: "Invalid"}}
+	input := &dto.LogoutInput{Authorization: "Invalid"}
 	_, err := handler(context.Background(), input)
 
 	assert.Error(t, err)
@@ -59,9 +55,7 @@ func TestLogout_ExpiredToken(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `json:"-"`
-	}{Authorization: "Bearer " + token}}
+	input := &dto.LogoutInput{Authorization: "Bearer " + token}
 	_, err := handler(context.Background(), input)
 
 	assert.Error(t, err)
@@ -79,9 +73,7 @@ func TestLogout_DBError(t *testing.T) {
 
 	handler := handlers.LogoutHandler(mockAuthSvc, mockTokenSvc)
 
-	input := &dto.LogoutInput{Header: struct {
-		Authorization string `json:"-"`
-	}{Authorization: "Bearer " + token}}
+	input := &dto.LogoutInput{Authorization: "Bearer " + token}
 	_, err := handler(context.Background(), input)
 
 	assert.Error(t, err)

--- a/internal/features/auth/handlers/resend_verification.go
+++ b/internal/features/auth/handlers/resend_verification.go
@@ -12,7 +12,7 @@ import (
 
 func ResendVerificationHandler(svc service.EmailVerificationService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.ResendVerificationInput) (*dto.ResendVerificationOutput, error) {
 	return func(ctx context.Context, input *dto.ResendVerificationInput) (*dto.ResendVerificationOutput, error) {
-		authHeader := input.Body.Authorization
+		authHeader := input.Header.Authorization
 		if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
 			return nil, huma.Error401Unauthorized("Invalid authorization header", nil)
 		}

--- a/internal/features/auth/handlers/resend_verification.go
+++ b/internal/features/auth/handlers/resend_verification.go
@@ -12,7 +12,7 @@ import (
 
 func ResendVerificationHandler(svc service.EmailVerificationService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.ResendVerificationInput) (*dto.ResendVerificationOutput, error) {
 	return func(ctx context.Context, input *dto.ResendVerificationInput) (*dto.ResendVerificationOutput, error) {
-		authHeader := input.Header.Authorization
+		authHeader := input.Authorization
 		if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
 			return nil, huma.Error401Unauthorized("Invalid authorization header", nil)
 		}

--- a/internal/features/auth/handlers/resend_verification_test.go
+++ b/internal/features/auth/handlers/resend_verification_test.go
@@ -22,7 +22,7 @@ func TestResendVerification_Successful(t *testing.T) {
 	token := "valid-access-token"
 
 	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{
-		"sub":  userID.String(),
+		"sub":   userID.String(),
 		"email": email,
 	}, nil)
 	mockSvc.On("ResendVerification", mock.Anything, userID, email).Return(nil)
@@ -30,7 +30,7 @@ func TestResendVerification_Successful(t *testing.T) {
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
 	input := &dto.ResendVerificationInput{}
-	input.Body.Authorization = "Bearer " + token
+	input.Header.Authorization = "Bearer " + token
 
 	resp, err := handler(context.Background(), input)
 
@@ -47,7 +47,7 @@ func TestResendVerification_InvalidAuthHeader(t *testing.T) {
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
 	input := &dto.ResendVerificationInput{}
-	input.Body.Authorization = "Invalid"
+	input.Header.Authorization = "Invalid"
 
 	resp, err := handler(context.Background(), input)
 
@@ -65,7 +65,7 @@ func TestResendVerification_InvalidToken(t *testing.T) {
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
 	input := &dto.ResendVerificationInput{}
-	input.Body.Authorization = "Bearer invalid-token"
+	input.Header.Authorization = "Bearer invalid-token"
 
 	resp, err := handler(context.Background(), input)
 
@@ -91,7 +91,7 @@ func TestResendVerification_RateLimitExceeded(t *testing.T) {
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
 	input := &dto.ResendVerificationInput{}
-	input.Body.Authorization = "Bearer " + token
+	input.Header.Authorization = "Bearer " + token
 
 	resp, err := handler(context.Background(), input)
 

--- a/internal/features/auth/handlers/resend_verification_test.go
+++ b/internal/features/auth/handlers/resend_verification_test.go
@@ -29,8 +29,7 @@ func TestResendVerification_Successful(t *testing.T) {
 
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
-	input := &dto.ResendVerificationInput{}
-	input.Header.Authorization = "Bearer " + token
+	input := &dto.ResendVerificationInput{Authorization: "Bearer " + token}
 
 	resp, err := handler(context.Background(), input)
 
@@ -46,8 +45,7 @@ func TestResendVerification_InvalidAuthHeader(t *testing.T) {
 	mockTokenSvc := new(MockTokenService)
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
-	input := &dto.ResendVerificationInput{}
-	input.Header.Authorization = "Invalid"
+	input := &dto.ResendVerificationInput{Authorization: "Invalid"}
 
 	resp, err := handler(context.Background(), input)
 
@@ -64,8 +62,7 @@ func TestResendVerification_InvalidToken(t *testing.T) {
 
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
-	input := &dto.ResendVerificationInput{}
-	input.Header.Authorization = "Bearer invalid-token"
+	input := &dto.ResendVerificationInput{Authorization: "Bearer invalid-token"}
 
 	resp, err := handler(context.Background(), input)
 
@@ -90,8 +87,7 @@ func TestResendVerification_RateLimitExceeded(t *testing.T) {
 
 	handler := handlers.ResendVerificationHandler(mockSvc, mockTokenSvc)
 
-	input := &dto.ResendVerificationInput{}
-	input.Header.Authorization = "Bearer " + token
+	input := &dto.ResendVerificationInput{Authorization: "Bearer " + token}
 
 	resp, err := handler(context.Background(), input)
 


### PR DESCRIPTION
## Summary
- Fix 2 endpoints that incorrectly accepted authorization tokens in request body instead of HTTP header
- Updated `/api/auth/logout` and `/api/auth/email/resend-verification` to use `Authorization: Bearer <token>` header
- Updated context documentation to establish the idiomatic huma header binding pattern

## Changes
- `dto/auth.go` - Changed `LogoutInput` to use idiomatic huma header binding: `Authorization string \`header:"Authorization"\``
- `dto/email_verification.go` - Changed `ResendVerificationInput` to use same pattern
- `handlers/logout.go` - Updated field access from `input.Header.Authorization` to `input.Authorization`
- `handlers/resend_verification.go` - Updated field access from `input.Header.Authorization` to `input.Authorization`
- Test files updated to match new structure
- `.opencode/context/project-intelligence/technical-domain.md` - Documented idiomatic huma header binding pattern

## Pattern Established
```go
// Header input (request headers) — idiomatic huma pattern:
type LogoutInput struct {
    Authorization string \`header:"Authorization" json:"-"\`
}
```