### PR TITLE
docs: add security scheme and required auth header to API docs

### DIFF
--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -73,6 +73,9 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string, emailCl
 		Path:        "/api/auth/email/resend-verification",
 		Summary:     "Resend verification email",
 		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
 	}, handlers.ResendVerificationHandler(emailVerifSvc, tokenSvc))
 
 	// Password reset routes (already use dto types)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -46,7 +46,15 @@ func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, func(),
 func setupHuma(router *chi.Mux) huma.API {
 	humaConfig := huma.DefaultConfig("MedMinder API", "1.0.0")
 	humaConfig.Info.Description = "Medication reminder application API"
-	humaConfig.DocsRenderer = huma.DocsRendererScalar
+	humaConfig.DocsRenderer = huma.DocsRendererSwaggerUI
 	humaConfig.DocsPath = "/api/docs"
+	humaConfig.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		"bearer": {
+			Type:         "http",
+			Scheme:       "bearer",
+			BearerFormat: "JWT",
+			Description:  "Enter your JWT token",
+		},
+	}
 	return humachi.New(router, humaConfig)
 }


### PR DESCRIPTION
## Summary

- Add `bearer` JWT security scheme to OpenAPI config
- Mark `POST /api/auth/email/resend-verification` endpoint as requiring Bearer authentication
- Switch API docs renderer from Scalar to SwaggerUI for better security visualization

## Changes

- `internal/router/router.go` — Added `SecuritySchemes` with `bearer` JWT config and switched to SwaggerUI
- `internal/features/auth/routes.go` — Added `Security` field to `resend-verification` operation

## Testing

- Build passes: `go build ./...`
- Auth handler tests pass: `go test ./internal/features/auth/... -run Resend`

## Notes

- The `resend-verification` endpoint now properly requires `Authorization: Bearer <token>` header
- SwaggerUI displays 🔒 lock icon for secured endpoints and has an Authorize button for global token input