### PR TITLE
♻️ refactor: extract auth service constants and wire common errors

### DIFF
--- a/internal/common/errors/errors.go
+++ b/internal/common/errors/errors.go
@@ -23,6 +23,8 @@ var (
 	ErrBadRequest = errors.New("bad request")
 	// ErrInternal is returned for unexpected internal server errors.
 	ErrInternal = errors.New("internal error")
+	// ErrTooManyRequests is returned when the client has exceeded rate limits.
+	ErrTooManyRequests = errors.New("too many requests")
 )
 
 func StatusCode(err error) int {

--- a/internal/features/auth/service/constants.go
+++ b/internal/features/auth/service/constants.go
@@ -1,0 +1,8 @@
+package service
+
+import "time"
+
+const (
+	BcryptCost         = 12
+	RefreshTokenExpiry = 7 * 24 * time.Hour
+)

--- a/internal/features/auth/service/errors.go
+++ b/internal/features/auth/service/errors.go
@@ -2,18 +2,15 @@ package service
 
 import (
 	"errors"
-	"time"
-)
+	"fmt"
 
-const (
-	BcryptCost         = 12
-	RefreshTokenExpiry = 7 * 24 * time.Hour
+	commonerrors "github.com/shuvo-paul/medminder/internal/common/errors"
 )
 
 var (
-	ErrEmailExists        = errors.New("email already exists")
-	ErrInvalidCredentials = errors.New("invalid credentials")
-	ErrLogoutFailed       = errors.New("logout failed")
-	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
-	ErrEmailNotFound      = errors.New("email not found")
+	ErrEmailExists        = fmt.Errorf("%w: %w", errors.New("email already exists"), commonerrors.ErrConflict)
+	ErrInvalidCredentials = fmt.Errorf("%w: %w", errors.New("invalid credentials"), commonerrors.ErrUnauthorized)
+	ErrLogoutFailed       = fmt.Errorf("%w: %w", errors.New("logout failed"), commonerrors.ErrInternal)
+	ErrRateLimitExceeded  = fmt.Errorf("%w: %w", errors.New("rate limit exceeded"), commonerrors.ErrTooManyRequests)
+	ErrEmailNotFound      = fmt.Errorf("%w: %w", errors.New("email not found"), commonerrors.ErrNotFound)
 )


### PR DESCRIPTION
## Summary
- Extract BcryptCost and RefreshTokenExpiry from errors.go into dedicated constants.go
- Wire auth service sentinel errors to wrap common/errors sentinels via fmt.Errorf wrapping
- Add ErrTooManyRequests to common/errors for rate limit semantic

## Changes
- internal/features/auth/service/constants.go (new) — BcryptCost, RefreshTokenExpiry
- internal/features/auth/service/errors.go — rewritten as wrapping errors
- internal/common/errors/errors.go — added ErrTooManyRequests

## Why
Constants were in the wrong file. common/errors existed but was unused. Now errors.Is checks work at both layers.

## Testing
go build ./... and go test ./internal/... pass.