### PR TITLE
♻️ refactor: add ErrTooManyRequests status mapping

### DIFF
--- a/internal/common/errors/errors.go
+++ b/internal/common/errors/errors.go
@@ -39,6 +39,8 @@ func StatusCode(err error) int {
 		return http.StatusConflict
 	case errors.Is(err, ErrBadRequest):
 		return http.StatusBadRequest
+	case errors.Is(err, ErrTooManyRequests):
+		return http.StatusTooManyRequests
 	default:
 		return http.StatusInternalServerError
 	}


### PR DESCRIPTION
## Summary
- Add `ErrTooManyRequests` status mapping to return `429 Too Many Requests` HTTP status

## Changes
- Modified `internal/common/errors/errors.go` to handle `ErrTooManyRequests` in `StatusCode()` function

## Testing
- `go test ./...` passes