### PR TITLE
Add OAuth error types

### DIFF
--- a/internal/features/auth/repository/errors.go
+++ b/internal/features/auth/repository/errors.go
@@ -6,4 +6,11 @@ var (
 	ErrTokenNotFound = errors.New("token not found")
 	ErrTokenExpired  = errors.New("token expired")
 	ErrTokenUsed     = errors.New("token already used")
+
+	// ErrOAuthAccountNotFound is returned when an OAuth account does not exist in the database.
+	ErrOAuthAccountNotFound = errors.New("oauth account not found")
+
+	// ErrOAuthCodeNotFound is returned when an OAuth authorization code is not found,
+	// already used, or expired. All three states return the same error to prevent timing oracles.
+	ErrOAuthCodeNotFound = errors.New("oauth code not found")
 )


### PR DESCRIPTION
## Summary

Adds two new error types in the auth repository:

- : returned when an OAuth account does not exist in the database
- : consolidated error for not found, used, or expired OAuth authorization codes to prevent timing oracles

## Changes

- Added  error
- Added  error with security-conscious design

Closes #73