### PR TITLE
feat(auth): add OAuth callback and token exchange endpoints

### DIFF
--- a/internal/common/database/migrations/000007_add_oauth_userinfo_columns.down.sql
+++ b/internal/common/database/migrations/000007_add_oauth_userinfo_columns.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE oauth_authorization_codes
+    DROP COLUMN IF EXISTS provider,
+    DROP COLUMN IF EXISTS provider_user_id,
+    DROP COLUMN IF EXISTS provider_email,
+    DROP COLUMN IF EXISTS provider_name,
+    DROP COLUMN IF EXISTS provider_email_verified;

--- a/internal/common/database/migrations/000007_add_oauth_userinfo_columns.up.sql
+++ b/internal/common/database/migrations/000007_add_oauth_userinfo_columns.up.sql
@@ -1,0 +1,9 @@
+-- Add user info columns to oauth_authorization_codes.
+-- The callback handler fetches user info from the OAuth provider and stores it here
+-- so the token exchange endpoint can call GetOrCreateUserByOAuth without re-fetching.
+ALTER TABLE oauth_authorization_codes
+    ADD COLUMN provider                VARCHAR(50)  NOT NULL DEFAULT '',
+    ADD COLUMN provider_user_id       VARCHAR(255) NOT NULL DEFAULT '',
+    ADD COLUMN provider_email          VARCHAR(255) NOT NULL DEFAULT '',
+    ADD COLUMN provider_name           VARCHAR(255) NOT NULL DEFAULT '',
+    ADD COLUMN provider_email_verified BOOLEAN      NOT NULL DEFAULT FALSE;

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -2,10 +2,14 @@ package handlers_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
+	db "github.com/shuvo-paul/medminder/internal/database/sqlc"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+	"github.com/shuvo-paul/medminder/pkg/oauth"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -75,5 +79,116 @@ func (m *MockEmailVerificationService) VerifyEmail(ctx context.Context, token st
 
 func (m *MockEmailVerificationService) ResendVerification(ctx context.Context, userID uuid.UUID, email string) error {
 	args := m.Called(ctx, userID, email)
+	return args.Error(0)
+}
+
+// -- OAuth mocks --
+
+type MockOAuthService struct {
+	mock.Mock
+}
+
+func (m *MockOAuthService) GetOrCreateUserByOAuth(ctx context.Context, provider string, userInfo *oauth.UserInfo) (*service.OAuthUser, error) {
+	args := m.Called(ctx, provider, userInfo)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*service.OAuthUser), args.Error(1)
+}
+
+func (m *MockOAuthService) GetUserByOAuth(ctx context.Context, provider, providerUserID string) (*service.OAuthUser, error) {
+	args := m.Called(ctx, provider, providerUserID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*service.OAuthUser), args.Error(1)
+}
+
+func (m *MockOAuthService) LinkOAuthAccount(ctx context.Context, userID uuid.UUID, provider, providerUserID string) error {
+	args := m.Called(ctx, userID, provider, providerUserID)
+	return args.Error(0)
+}
+
+func (m *MockOAuthService) UnlinkOAuthAccount(ctx context.Context, userID uuid.UUID, provider string) error {
+	args := m.Called(ctx, userID, provider)
+	return args.Error(0)
+}
+
+func (m *MockOAuthService) GetUserOAuthProviders(ctx context.Context, userID uuid.UUID) ([]string, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockOAuthService) CanUnlinkProvider(ctx context.Context, userID uuid.UUID, provider string) (bool, error) {
+	args := m.Called(ctx, userID, provider)
+	return args.Bool(0), args.Error(1)
+}
+
+type MockRefreshTokenRepository struct {
+	mock.Mock
+}
+
+func (m *MockRefreshTokenRepository) CreateRefreshToken(ctx context.Context, userID uuid.UUID, tokenHash string, expiresAt time.Time) (db.CreateRefreshTokenRow, error) {
+	args := m.Called(ctx, userID, tokenHash, expiresAt)
+	return args.Get(0).(db.CreateRefreshTokenRow), args.Error(1)
+}
+
+func (m *MockRefreshTokenRepository) GetRefreshTokenByHash(ctx context.Context, tokenHash string) (db.RefreshToken, error) {
+	args := m.Called(ctx, tokenHash)
+	return args.Get(0).(db.RefreshToken), args.Error(1)
+}
+
+func (m *MockRefreshTokenRepository) DeleteRefreshToken(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockRefreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+func (m *MockRefreshTokenRepository) DeleteAllForUser(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
+type MockOAuthAuthorizationCodeRepository struct {
+	mock.Mock
+}
+
+func (m *MockOAuthAuthorizationCodeRepository) CreateAuthorizationCode(ctx context.Context, id uuid.UUID, codeHash string, userID uuid.NullUUID, nonce string, purpose string, expiresAt time.Time) (db.OauthAuthorizationCode, error) {
+	args := m.Called(ctx, id, codeHash, userID, nonce, purpose, expiresAt)
+	return args.Get(0).(db.OauthAuthorizationCode), args.Error(1)
+}
+
+func (m *MockOAuthAuthorizationCodeRepository) CreateAuthorizationCodeWithUserInfo(ctx context.Context, id uuid.UUID, codeHash string, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error) {
+	args := m.Called(ctx, id, codeHash, nonce, purpose, expiresAt, provider, providerUserID, providerEmail, providerName, providerEmailVerified)
+	return args.Get(0).(db.OauthAuthorizationCode), args.Error(1)
+}
+
+func (m *MockOAuthAuthorizationCodeRepository) GetAuthorizationCodeByHash(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error) {
+	args := m.Called(ctx, codeHash)
+	return args.Get(0).(db.OauthAuthorizationCode), args.Error(1)
+}
+
+func (m *MockOAuthAuthorizationCodeRepository) GetAndLockAuthorizationCode(ctx context.Context, codeHash string) (*repository.AuthorizationCodeInfo, error) {
+	args := m.Called(ctx, codeHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.AuthorizationCodeInfo), args.Error(1)
+}
+
+func (m *MockOAuthAuthorizationCodeRepository) MarkAuthorizationCodeAsUsed(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error) {
+	args := m.Called(ctx, codeHash)
+	return args.Get(0).(db.OauthAuthorizationCode), args.Error(1)
+}
+
+func (m *MockOAuthAuthorizationCodeRepository) CleanupExpiredAuthorizationCodes(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -2,14 +2,28 @@ package handlers
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/google/uuid"
+
 	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
+	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 	"github.com/shuvo-paul/medminder/pkg/oauth"
 )
+
+// oauthAuthCodeExpiry is the lifetime of an internal authorization code.
+const oauthAuthCodeExpiry = 5 * time.Minute
 
 // ListOAuthProvidersHandler returns a handler that lists all configured OAuth providers.
 // GET /api/auth/oauth/providers
@@ -69,8 +83,23 @@ func InitiateOAuthHandler() func(context.Context, *dto.InitiateOAuthInput) (*dto
 	}
 }
 
+// OAuthHandlerDeps groups dependencies needed by OAuth handlers.
+type OAuthHandlerDeps struct {
+	AuthCodeRepo repository.OAuthAuthorizationCodeRepository
+	OAuthSvc     service.OAuthService
+	TokenSvc     service.TokenServiceInterface
+	TokenRepo    repository.RefreshTokenRepository
+}
+
 // RegisterOAuthProviderRoutes registers the OAuth provider routes.
-func RegisterOAuthProviderRoutes(api huma.API) {
+func RegisterOAuthProviderRoutes(api huma.API, authCodeRepo repository.OAuthAuthorizationCodeRepository, oauthSvc service.OAuthService, tokenSvc service.TokenServiceInterface, tokenRepo repository.RefreshTokenRepository) {
+	deps := &OAuthHandlerDeps{
+		AuthCodeRepo: authCodeRepo,
+		OAuthSvc:     oauthSvc,
+		TokenSvc:     tokenSvc,
+		TokenRepo:    tokenRepo,
+	}
+
 	// List providers - unauthenticated
 	huma.Register(api, huma.Operation{
 		OperationID: "list-oauth-providers",
@@ -96,7 +125,16 @@ func RegisterOAuthProviderRoutes(api huma.API) {
 		Path:        "/api/auth/oauth/{provider}/callback",
 		Summary:     "Handle OAuth callback",
 		Tags:        []string{"auth"},
-	}, OAuthCallbackHandler())
+	}, OAuthCallbackHandler(deps))
+
+	// Token exchange - unauthenticated
+	huma.Register(api, huma.Operation{
+		OperationID: "oauth-token-exchange",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/oauth/token",
+		Summary:     "Exchange OAuth authorization code for JWT tokens",
+		Tags:        []string{"auth"},
+	}, TokenExchangeHandler(deps))
 }
 
 // isValidRedirect checks if the redirect URL is a relative path or a trusted domain.
@@ -120,14 +158,222 @@ func isValidRedirect(redirect string) bool {
 	return false
 }
 
-// OAuthCallbackHandler returns a handler that handles OAuth callback.
+// OAuthCallbackHandler returns a handler that handles the OAuth callback from the provider.
 // GET /api/auth/oauth/{provider}/callback
-func OAuthCallbackHandler() func(context.Context, *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutput, error) {
+//
+// Two modes:
+//   - Error mode (provider returns ?error=...): redirects to frontend with error info
+//   - Success mode (provider returns ?code=...): exchanges code, stores user info internally,
+//     and redirects to frontend callback route with an internal authorization code.
+func OAuthCallbackHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutput, error) {
 	return func(ctx context.Context, input *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutput, error) {
-		// TODO: Implement OAuth callback - exchange code for tokens and complete authentication
-		// This is a placeholder that returns the received parameters
+		// --- Mode 1: Provider error ---
+		if input.Error != "" {
+			return handleProviderError(input)
+		}
+
+		// --- Mode 2: Success (authorization code received) ---
+		if input.Code == "" {
+			return nil, huma.Error400BadRequest("missing authorization code", errors.New("code parameter is required"))
+		}
+
+		// Parse and validate state
+		state, err := dto.ParseOAuthState(input.State)
+		if err != nil {
+			return &dto.OAuthCallbackOutput{
+				Redirect: "/login?oauth_error=invalid_state",
+			}, nil
+		}
+
+		// Get the provider from registry
+		provider, err := oauth.GetProvider(input.Provider)
+		if err != nil {
+			return nil, huma.Error404NotFound("provider not found", err)
+		}
+
+		// Exchange the authorization code for tokens
+		tokenResp, err := provider.ExchangeCode(ctx, input.Code)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to exchange authorization code", err)
+		}
+
+		// Fetch user info from provider
+		userInfo, err := provider.GetUserInfo(ctx, tokenResp.AccessToken)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to get user info", err)
+		}
+
+		// Generate internal authorization code
+		internalCode, codeHash, err := generateAuthCode()
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to generate authorization code", err)
+		}
+
+		// Store in database (5-minute expiry, SHA-256 hashed)
+		expiresAt := time.Now().Add(oauthAuthCodeExpiry)
+		_, err = deps.AuthCodeRepo.CreateAuthorizationCodeWithUserInfo(
+			ctx,
+			uuid.New(),
+			codeHash,
+			state.Nonce,
+			state.Purpose,
+			expiresAt,
+			input.Provider,
+			userInfo.ProviderUserID,
+			userInfo.Email,
+			userInfo.Name,
+			userInfo.EmailVerified,
+		)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to store authorization code", err)
+		}
+
+		// Encode original state to pass back to frontend
+		encodedState, err := json.Marshal(state)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to encode state", err)
+		}
+
+		// 302 redirect to frontend callback route (NO JWT tokens in URL)
+		redirectURL := fmt.Sprintf("/auth/callback?code=%s&state=%s",
+			url.QueryEscape(internalCode),
+			url.QueryEscape(string(encodedState)),
+		)
+
 		return &dto.OAuthCallbackOutput{
-			Redirect: input.State,
+			Redirect: redirectURL,
 		}, nil
 	}
+}
+
+// TokenExchangeHandler returns a handler that exchanges an internal OAuth authorization
+// code for JWT access and refresh tokens.
+// POST /api/auth/oauth/token
+func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthTokenRequest) (*dto.OAuthTokenResponse, error) {
+	return func(ctx context.Context, input *dto.OAuthTokenRequest) (*dto.OAuthTokenResponse, error) {
+		// Parse and validate state
+		state, err := dto.ParseOAuthState(input.State)
+		if err != nil {
+			return nil, huma.Error401Unauthorized("invalid state", err)
+		}
+
+		// Hash the received code
+		codeHash := hashCode(input.Code)
+
+		// Look up and lock the authorization code (prevents concurrent redemption)
+		authCodeInfo, err := deps.AuthCodeRepo.GetAndLockAuthorizationCode(ctx, codeHash)
+		if err != nil {
+			return nil, huma.Error401Unauthorized(string(dto.OAuthErrorInvalidCode),
+				fmt.Errorf("invalid or expired authorization code"))
+		}
+
+		// Verify nonce matches (CSRF protection)
+		if authCodeInfo.Nonce != state.Nonce {
+			// Mark as used to prevent replay attempts
+			_, _ = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
+			return nil, huma.Error401Unauthorized(string(dto.OAuthErrorInvalidCode),
+				fmt.Errorf("state nonce mismatch"))
+		}
+
+		// Get or create user by OAuth
+		oauthUser, err := deps.OAuthSvc.GetOrCreateUserByOAuth(ctx, authCodeInfo.Provider, &oauth.UserInfo{
+			ProviderUserID: authCodeInfo.ProviderUserID,
+			Email:          authCodeInfo.ProviderEmail,
+			EmailVerified:  authCodeInfo.ProviderEmailVerified,
+			Name:           authCodeInfo.ProviderName,
+		})
+		if err != nil {
+			// Mark code as used even on error to prevent further attempts
+			_, _ = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
+
+			if errors.Is(err, service.ErrEmailExists) {
+				return nil, huma.Error409Conflict(string(dto.OAuthErrorEmailExists),
+					fmt.Errorf("email already exists"))
+			}
+			return nil, huma.Error500InternalServerError("authentication failed", err)
+		}
+
+		// Mark authorization code as used (one-time use)
+		_, err = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to mark code as used", err)
+		}
+
+		// Generate JWT access token
+		accessToken, err := deps.TokenSvc.GenerateAccessToken(oauthUser.ID, oauthUser.Email)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to generate access token", err)
+		}
+
+		// Generate refresh token
+		refreshToken, err := deps.TokenSvc.GenerateRefreshToken()
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to generate refresh token", err)
+		}
+
+		// Store refresh token hash in database
+		refreshTokenHash := deps.TokenSvc.HashRefreshToken(refreshToken)
+		refreshExpiry := time.Now().Add(service.RefreshTokenExpiry)
+		if _, err := deps.TokenRepo.CreateRefreshToken(ctx, oauthUser.ID, refreshTokenHash, refreshExpiry); err != nil {
+			return nil, huma.Error500InternalServerError("failed to store refresh token", err)
+		}
+
+		return &dto.OAuthTokenResponse{
+			AccessToken:  accessToken,
+			RefreshToken: refreshToken,
+			TokenType:    "Bearer",
+			ExpiresIn:    int(service.AccessTokenExpiry.Seconds()),
+			User: dto.OAuthTokenUserInfo{
+				ID:            oauthUser.ID.String(),
+				Email:         oauthUser.Email,
+				DisplayName:   oauthUser.DisplayName,
+				EmailVerified: oauthUser.EmailVerified,
+			},
+		}, nil
+	}
+}
+
+// handleProviderError handles the error case where the OAuth provider returned an error
+// (e.g., user denied access). It attempts to parse the state to redirect back to the
+// original frontend page, falling back to /login if state is absent or malformed.
+func handleProviderError(input *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutput, error) {
+	if input.State == "" {
+		return &dto.OAuthCallbackOutput{
+			Redirect: "/login?oauth_error=cancelled",
+		}, nil
+	}
+
+	state, err := dto.ParseOAuthState(input.State)
+	if err != nil || state.Redirect == "" {
+		return &dto.OAuthCallbackOutput{
+			Redirect: "/login?oauth_error=cancelled",
+		}, nil
+	}
+
+	redirectURL := fmt.Sprintf("%s?oauth_error=cancelled&provider=%s",
+		state.Redirect,
+		url.QueryEscape(input.Provider),
+	)
+
+	return &dto.OAuthCallbackOutput{
+		Redirect: redirectURL,
+	}, nil
+}
+
+// generateAuthCode creates a cryptographically random authorization code and its SHA-256 hash.
+// Returns the raw code (for the frontend) and the hash (for database storage).
+func generateAuthCode() (rawCode, hash string, err error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", "", fmt.Errorf("failed to generate random code: %w", err)
+	}
+	rawCode = hex.EncodeToString(bytes)
+	hash = hashCode(rawCode)
+	return rawCode, hash, nil
+}
+
+// hashCode returns the SHA-256 hex hash of the given code.
+func hashCode(code string) string {
+	sum := sha256.Sum256([]byte(code))
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -8,10 +8,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	db "github.com/shuvo-paul/medminder/internal/database/sqlc"
 	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
 	"github.com/shuvo-paul/medminder/internal/features/auth/handlers"
+	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
+	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 	"github.com/shuvo-paul/medminder/pkg/oauth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -169,4 +174,354 @@ func TestInitiateOAuthHandler_ProviderNotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	assert.True(t, strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "Provider not found"))
+}
+
+// -- OAuth Callback Handler Tests --
+
+// newCallbackDeps creates dependencies for testing the callback handler.
+func newCallbackDeps() *handlers.OAuthHandlerDeps {
+	return &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: &MockOAuthAuthorizationCodeRepository{},
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+	}
+}
+
+func TestOAuthCallbackHandler_ProviderError_WithState(t *testing.T) {
+	deps := newCallbackDeps()
+	handler := handlers.OAuthCallbackHandler(deps)
+
+	state := encodeOAuthState("test-nonce", "/dashboard", "login")
+	input := &dto.OAuthCallbackInput{
+		Provider: "google",
+		Error:    "access_denied",
+		State:    state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "/dashboard?oauth_error=cancelled&provider=google", resp.Redirect)
+}
+
+func TestOAuthCallbackHandler_ProviderError_EmptyState(t *testing.T) {
+	deps := newCallbackDeps()
+	handler := handlers.OAuthCallbackHandler(deps)
+
+	input := &dto.OAuthCallbackInput{
+		Provider: "google",
+		Error:    "access_denied",
+		State:    "",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "/login?oauth_error=cancelled", resp.Redirect)
+}
+
+func TestOAuthCallbackHandler_ProviderError_MalformedState(t *testing.T) {
+	deps := newCallbackDeps()
+	handler := handlers.OAuthCallbackHandler(deps)
+
+	input := &dto.OAuthCallbackInput{
+		Provider: "google",
+		Error:    "access_denied",
+		State:    "not-valid-base64!!!",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "/login?oauth_error=cancelled", resp.Redirect)
+}
+
+func TestOAuthCallbackHandler_MissingCode(t *testing.T) {
+	deps := newCallbackDeps()
+	handler := handlers.OAuthCallbackHandler(deps)
+
+	state := encodeOAuthState("test-nonce", "/dashboard", "login")
+	input := &dto.OAuthCallbackInput{
+		Provider: "google",
+		State:    state,
+		// No Code, No Error
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	require.Contains(t, err.Error(), "code")
+}
+
+func TestOAuthCallbackHandler_Success(t *testing.T) {
+	// Set up environment and register a mock provider
+	os.Setenv("TEST_CALLBACK_ID", "test-id")
+	os.Setenv("TEST_CALLBACK_SECRET", "test-secret")
+	os.Setenv("TEST_CALLBACK_REDIRECT", "http://localhost:8080/callback")
+	defer func() {
+		os.Unsetenv("TEST_CALLBACK_ID")
+		os.Unsetenv("TEST_CALLBACK_SECRET")
+		os.Unsetenv("TEST_CALLBACK_REDIRECT")
+	}()
+
+	mockProvider := &oauth.MockProvider{
+		NameVal:            "google",
+		RequiredEnvVarsVal: []string{"TEST_CALLBACK_ID", "TEST_CALLBACK_SECRET", "TEST_CALLBACK_REDIRECT"},
+		ExchangeCodeResp: &oauth.TokenResponse{
+			AccessToken: "google-access-token",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		},
+		GetUserInfoResp: &oauth.UserInfo{
+			ProviderUserID: "google-user-123",
+			Email:          "test@example.com",
+			EmailVerified:  true,
+			Name:           "Test User",
+		},
+	}
+	_ = oauth.Register(mockProvider)
+
+	// Set up mock authorization code repository
+	mockCodeRepo := new(MockOAuthAuthorizationCodeRepository)
+	mockCodeRepo.On("CreateAuthorizationCodeWithUserInfo",
+		mock.Anything,
+		mock.Anything, // id
+		mock.Anything, // codeHash
+		"test-nonce",  // nonce
+		"login",       // purpose
+		mock.Anything, // expiresAt
+		"google",      // provider
+		"google-user-123",
+		"test@example.com",
+		"Test User",
+		true,
+	).Return(db.OauthAuthorizationCode{}, nil)
+
+	deps := &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: mockCodeRepo,
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+	}
+	handler := handlers.OAuthCallbackHandler(deps)
+
+	state := encodeOAuthState("test-nonce", "/dashboard", "login")
+	input := &dto.OAuthCallbackInput{
+		Provider: "google",
+		Code:     "google-auth-code",
+		State:    state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Redirect, "/auth/callback?code=")
+	assert.Contains(t, resp.Redirect, "&state=")
+	// No JWT tokens in the redirect URL
+	assert.NotContains(t, resp.Redirect, "access_token")
+	assert.NotContains(t, resp.Redirect, "refresh_token")
+}
+
+// -- Token Exchange Handler Tests --
+
+func TestTokenExchangeHandler_Success(t *testing.T) {
+	mockCodeRepo := new(MockOAuthAuthorizationCodeRepository)
+	mockOAuthSvc := new(MockOAuthService)
+	mockTokenSvc := new(MockTokenService)
+	mockTokenRepo := new(MockRefreshTokenRepository)
+
+	userID := uuid.New()
+
+	// Mock authorization code lookup
+	authCodeInfo := &repository.AuthorizationCodeInfo{
+		OauthAuthorizationCode: db.OauthAuthorizationCode{
+			CodeHash: "test-code-hash",
+			Nonce:    "test-nonce-123",
+			Purpose:  "login",
+		},
+		Provider:              "google",
+		ProviderUserID:        "google-user-123",
+		ProviderEmail:         "test@example.com",
+		ProviderName:          "Test User",
+		ProviderEmailVerified: true,
+	}
+	mockCodeRepo.On("GetAndLockAuthorizationCode", mock.Anything, mock.Anything).Return(authCodeInfo, nil)
+	mockCodeRepo.On("MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything).Return(db.OauthAuthorizationCode{}, nil)
+
+	// Mock OAuth service
+	mockOAuthSvc.On("GetOrCreateUserByOAuth", mock.Anything, "google", mock.Anything).Return(&service.OAuthUser{
+		ID:            userID,
+		Email:         "test@example.com",
+		DisplayName:   "Test User",
+		EmailVerified: true,
+	}, nil)
+
+	// Mock token generation
+	mockTokenSvc.On("GenerateAccessToken", userID, "test@example.com").Return("access-token-xyz", nil)
+	mockTokenSvc.On("GenerateRefreshToken").Return("refresh-token-xyz", nil)
+	mockTokenSvc.On("HashRefreshToken", "refresh-token-xyz").Return("hashed-refresh-token")
+	mockTokenRepo.On("CreateRefreshToken", mock.Anything, userID, "hashed-refresh-token", mock.Anything).Return(db.CreateRefreshTokenRow{}, nil)
+
+	deps := &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: mockCodeRepo,
+		OAuthSvc:     mockOAuthSvc,
+		TokenSvc:     mockTokenSvc,
+		TokenRepo:    mockTokenRepo,
+	}
+	handler := handlers.TokenExchangeHandler(deps)
+
+	// Generate a proper code hash for the state nonce to match
+	rawCode := "raw-internal-code"
+
+	state := encodeOAuthState("test-nonce-123", "/dashboard", "login")
+	input := &dto.OAuthTokenRequest{
+		Code:  rawCode,
+		State: state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "access-token-xyz", resp.AccessToken)
+	assert.Equal(t, "refresh-token-xyz", resp.RefreshToken)
+	assert.Equal(t, "Bearer", resp.TokenType)
+	assert.Equal(t, int(service.AccessTokenExpiry.Seconds()), resp.ExpiresIn)
+	assert.Equal(t, userID.String(), resp.User.ID)
+	assert.Equal(t, "test@example.com", resp.User.Email)
+}
+
+func TestTokenExchangeHandler_InvalidCode(t *testing.T) {
+	mockCodeRepo := new(MockOAuthAuthorizationCodeRepository)
+	mockCodeRepo.On("GetAndLockAuthorizationCode", mock.Anything, mock.Anything).Return(nil, repository.ErrOAuthCodeNotFound)
+
+	deps := &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: mockCodeRepo,
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+	}
+	handler := handlers.TokenExchangeHandler(deps)
+
+	state := encodeOAuthState("test-nonce", "/dashboard", "login")
+	input := &dto.OAuthTokenRequest{
+		Code:  "invalid-code",
+		State: state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), string(dto.OAuthErrorInvalidCode))
+}
+
+func TestTokenExchangeHandler_NonceMismatch(t *testing.T) {
+	mockCodeRepo := new(MockOAuthAuthorizationCodeRepository)
+
+	authCodeInfo := &repository.AuthorizationCodeInfo{
+		OauthAuthorizationCode: db.OauthAuthorizationCode{
+			CodeHash: "test-code-hash",
+			Nonce:    "different-nonce", // Different from state
+			Purpose:  "login",
+		},
+		Provider:              "google",
+		ProviderUserID:        "google-user-123",
+		ProviderEmail:         "test@example.com",
+		ProviderName:          "Test User",
+		ProviderEmailVerified: true,
+	}
+	mockCodeRepo.On("GetAndLockAuthorizationCode", mock.Anything, mock.Anything).Return(authCodeInfo, nil)
+	// Nonce mismatch marks code as used
+	mockCodeRepo.On("MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything).Return(db.OauthAuthorizationCode{}, nil)
+
+	deps := &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: mockCodeRepo,
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+	}
+	handler := handlers.TokenExchangeHandler(deps)
+
+	state := encodeOAuthState("correct-nonce", "/dashboard", "login")
+	input := &dto.OAuthTokenRequest{
+		Code:  "some-code",
+		State: state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), string(dto.OAuthErrorInvalidCode))
+	mockCodeRepo.AssertCalled(t, "MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything)
+}
+
+func TestTokenExchangeHandler_EmailExists(t *testing.T) {
+	mockCodeRepo := new(MockOAuthAuthorizationCodeRepository)
+	mockOAuthSvc := new(MockOAuthService)
+
+	authCodeInfo := &repository.AuthorizationCodeInfo{
+		OauthAuthorizationCode: db.OauthAuthorizationCode{
+			CodeHash: "test-code-hash",
+			Nonce:    "test-nonce",
+			Purpose:  "login",
+		},
+		Provider:              "google",
+		ProviderUserID:        "google-user-123",
+		ProviderEmail:         "exists@example.com",
+		ProviderName:          "Existing User",
+		ProviderEmailVerified: true,
+	}
+	mockCodeRepo.On("GetAndLockAuthorizationCode", mock.Anything, mock.Anything).Return(authCodeInfo, nil)
+	mockCodeRepo.On("MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything).Return(db.OauthAuthorizationCode{}, nil)
+
+	mockOAuthSvc.On("GetOrCreateUserByOAuth", mock.Anything, "google", mock.Anything).Return(nil, service.ErrEmailExists)
+
+	deps := &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: mockCodeRepo,
+		OAuthSvc:     mockOAuthSvc,
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+	}
+	handler := handlers.TokenExchangeHandler(deps)
+
+	state := encodeOAuthState("test-nonce", "/dashboard", "login")
+	input := &dto.OAuthTokenRequest{
+		Code:  "some-code",
+		State: state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), string(dto.OAuthErrorEmailExists))
+	mockCodeRepo.AssertCalled(t, "MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything)
+}
+
+func TestTokenExchangeHandler_MalformedState(t *testing.T) {
+	deps := &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: &MockOAuthAuthorizationCodeRepository{},
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+	}
+	handler := handlers.TokenExchangeHandler(deps)
+
+	input := &dto.OAuthTokenRequest{
+		Code:  "some-code",
+		State: "not-valid-base64!!!",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
 }

--- a/internal/features/auth/repository/oauth_repository.go
+++ b/internal/features/auth/repository/oauth_repository.go
@@ -20,11 +20,23 @@ type OAuthAccountRepository interface {
 	DeleteOAuthAccountByUserIDAndProvider(ctx context.Context, userID uuid.UUID, provider string) error
 }
 
+// AuthorizationCodeInfo holds the full authorization code data including provider user info.
+// This extends db.OauthAuthorizationCode with the columns added by migration 000007.
+type AuthorizationCodeInfo struct {
+	db.OauthAuthorizationCode
+	Provider              string
+	ProviderUserID        string
+	ProviderEmail         string
+	ProviderName          string
+	ProviderEmailVerified bool
+}
+
 // OAuthAuthorizationCodeRepository defines the interface for OAuth authorization code data access.
 type OAuthAuthorizationCodeRepository interface {
 	CreateAuthorizationCode(ctx context.Context, id uuid.UUID, codeHash string, userID uuid.NullUUID, nonce string, purpose string, expiresAt time.Time) (db.OauthAuthorizationCode, error)
+	CreateAuthorizationCodeWithUserInfo(ctx context.Context, id uuid.UUID, codeHash string, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error)
 	GetAuthorizationCodeByHash(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error)
-	GetAndLockAuthorizationCode(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error)
+	GetAndLockAuthorizationCode(ctx context.Context, codeHash string) (*AuthorizationCodeInfo, error)
 	MarkAuthorizationCodeAsUsed(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error)
 	CleanupExpiredAuthorizationCodes(ctx context.Context) error
 }
@@ -113,6 +125,26 @@ func (r *oauthAuthorizationCodeRepository) CreateAuthorizationCode(ctx context.C
 	})
 }
 
+func (r *oauthAuthorizationCodeRepository) CreateAuthorizationCodeWithUserInfo(ctx context.Context, id uuid.UUID, codeHash string, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error) {
+	const query = `
+		INSERT INTO oauth_authorization_codes (id, code_hash, user_id, nonce, purpose, expires_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified)
+		VALUES ($1, $2, NULL, $3, $4, $5, NOW(), $6, $7, $8, $9, $10)
+		RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at
+	`
+	var code db.OauthAuthorizationCode
+	err := r.db.QueryRowContext(ctx, query,
+		id, codeHash, nonce, purpose, expiresAt,
+		provider, providerUserID, providerEmail, providerName, providerEmailVerified,
+	).Scan(
+		&code.ID, &code.CodeHash, &code.UserID, &code.Nonce, &code.Purpose,
+		&code.ExpiresAt, &code.UsedAt, &code.CreatedAt,
+	)
+	if err != nil {
+		return db.OauthAuthorizationCode{}, err
+	}
+	return code, nil
+}
+
 func (r *oauthAuthorizationCodeRepository) GetAuthorizationCodeByHash(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error) {
 	code, err := r.queries.GetAuthorizationCodeByHash(ctx, codeHash)
 	if err != nil {
@@ -128,35 +160,70 @@ func (r *oauthAuthorizationCodeRepository) GetAuthorizationCodeByHash(ctx contex
 // SELECT FOR UPDATE within a transaction. This prevents concurrent code redemption.
 // All error cases (not found, already used, expired) return ErrOAuthCodeNotFound
 // to avoid leaking timing information about code state.
-func (r *oauthAuthorizationCodeRepository) GetAndLockAuthorizationCode(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error) {
+// Returns the extended AuthorizationCodeInfo which includes provider user info
+// columns (migration 000007) needed for GetOrCreateUserByOAuth.
+func (r *oauthAuthorizationCodeRepository) GetAndLockAuthorizationCode(ctx context.Context, codeHash string) (*AuthorizationCodeInfo, error) {
 	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		return db.OauthAuthorizationCode{}, ErrOAuthCodeNotFound
+		return nil, ErrOAuthCodeNotFound
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	code, err := r.lockAuthorizationCodeInTx(ctx, tx, codeHash)
+	info, err := r.lockAuthorizationCodeWithUserInfoInTx(ctx, tx, codeHash)
 	if err != nil {
-		return db.OauthAuthorizationCode{}, ErrOAuthCodeNotFound
+		return nil, ErrOAuthCodeNotFound
 	}
 
 	// Validate usage and expiry. All failures return the same error to prevent
 	// timing oracles — the caller will only see ErrOAuthCodeNotFound.
-	if code.UsedAt.Valid {
-		return db.OauthAuthorizationCode{}, ErrOAuthCodeNotFound
+	if info.UsedAt.Valid {
+		return nil, ErrOAuthCodeNotFound
 	}
-	if time.Now().After(code.ExpiresAt) {
-		return db.OauthAuthorizationCode{}, ErrOAuthCodeNotFound
+	if time.Now().After(info.ExpiresAt) {
+		return nil, ErrOAuthCodeNotFound
 	}
 
 	// Commit the transaction and return the valid code.
 	if err := tx.Commit(); err != nil {
-		return db.OauthAuthorizationCode{}, ErrOAuthCodeNotFound
+		return nil, ErrOAuthCodeNotFound
 	}
-	return code, nil
+	return info, nil
+}
+
+// lockAuthorizationCodeWithUserInfoInTx executes SELECT FOR UPDATE within the given transaction
+// and returns the extended AuthorizationCodeInfo including provider user info columns.
+func (r *oauthAuthorizationCodeRepository) lockAuthorizationCodeWithUserInfoInTx(ctx context.Context, tx *sql.Tx, codeHash string) (*AuthorizationCodeInfo, error) {
+	const query = `
+		SELECT id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at,
+		       provider, provider_user_id, provider_email, provider_name, provider_email_verified
+		FROM oauth_authorization_codes
+		WHERE code_hash = $1
+		FOR UPDATE
+	`
+	info := &AuthorizationCodeInfo{}
+	err := tx.QueryRowContext(ctx, query, codeHash).Scan(
+		&info.ID,
+		&info.CodeHash,
+		&info.UserID,
+		&info.Nonce,
+		&info.Purpose,
+		&info.ExpiresAt,
+		&info.UsedAt,
+		&info.CreatedAt,
+		&info.Provider,
+		&info.ProviderUserID,
+		&info.ProviderEmail,
+		&info.ProviderName,
+		&info.ProviderEmailVerified,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 // lockAuthorizationCodeInTx executes SELECT FOR UPDATE within the given transaction.
+// Deprecated: use lockAuthorizationCodeWithUserInfoInTx for extended info.
 func (r *oauthAuthorizationCodeRepository) lockAuthorizationCodeInTx(ctx context.Context, tx *sql.Tx, codeHash string) (db.OauthAuthorizationCode, error) {
 	const query = `
 		SELECT id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"database/sql"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -12,7 +13,7 @@ import (
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 )
 
-func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string, emailClient email.EmailClient, frontendURL string) {
+func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, jwtSecret string, emailClient email.EmailClient, frontendURL string) {
 	// Repos (used to construct services)
 	userRepo := repository.NewUserRepository(queries)
 	tokenRepo := repository.NewRefreshTokenRepository(queries)
@@ -29,6 +30,11 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string, emailCl
 		emailClient,
 		frontendURL,
 	)
+
+	// OAuth
+	oauthAccountRepo := repository.NewOAuthAccountRepository(queries)
+	oauthAuthCodeRepo := repository.NewOAuthAuthorizationCodeRepository(dbConn, queries)
+	oauthSvc := service.NewOAuthService(userRepo, oauthAccountRepo)
 
 	// Register (with email verification)
 	huma.Register(api, huma.Operation{
@@ -83,5 +89,5 @@ func RegisterRoutes(api huma.API, queries *db.Queries, jwtSecret string, emailCl
 	handlers.RegisterPasswordResetRoutes(api, passwordResetDeps)
 
 	// OAuth provider routes (unauthenticated)
-	handlers.RegisterOAuthProviderRoutes(api)
+	handlers.RegisterOAuthProviderRoutes(api, oauthAuthCodeRepo, oauthSvc, tokenSvc, tokenRepo)
 }

--- a/internal/features/auth/service/token.go
+++ b/internal/features/auth/service/token.go
@@ -12,10 +12,14 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	// AccessTokenExpiry is the lifetime of access tokens.
+	AccessTokenExpiry = 24 * time.Hour
+)
+
 var (
 	ErrInvalidToken      = errors.New("invalid token")
 	ErrTokenExpired      = errors.New("token expired")
-	accessTokenExpiry    = 24 * time.Hour
 	refreshTokenByteSize = 32
 )
 
@@ -38,7 +42,7 @@ func (ts *TokenService) GenerateAccessToken(userID uuid.UUID, email string) (str
 	claims := jwt.MapClaims{
 		"sub":   userID.String(),
 		"email": email,
-		"exp":   time.Now().Add(accessTokenExpiry).Unix(),
+		"exp":   time.Now().Add(AccessTokenExpiry).Unix(),
 		"iat":   time.Now().Unix(),
 	}
 
@@ -87,7 +91,7 @@ func GenerateAccessToken(userID uuid.UUID, email, jwtSecret string) (string, err
 	claims := jwt.MapClaims{
 		"sub":   userID.String(),
 		"email": email,
-		"exp":   time.Now().Add(accessTokenExpiry).Unix(),
+		"exp":   time.Now().Add(AccessTokenExpiry).Unix(),
 		"iat":   time.Now().Unix(),
 	}
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -49,7 +49,7 @@ func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, func(),
 	emailClient := email.NewEmailClient(cfg.Email)
 	email.StartEmailQueue(emailClient, 3, nil)
 
-	auth.RegisterRoutes(api, queries, cfg.JWT.Secret, emailClient, cfg.FrontendURL)
+	auth.RegisterRoutes(api, dbConn, queries, cfg.JWT.Secret, emailClient, cfg.FrontendURL)
 
 	registerHealthRoute(api)
 	registerOpenAPIRoute(router, api)


### PR DESCRIPTION
Implements the OAuth callback handler and token exchange endpoint for the OAuth login flow.

### Changes

- **OAuthCallbackHandler** — Handles both error (provider returns ?error=) and success modes. Exchanges the Google auth code for an access token, fetches user info, stores it with a SHA-256 hashed internal auth code in oauth_authorization_codes, and redirects to frontend with the internal code (no JWT in URL).
- **TokenExchangeHandler** — POST /api/auth/oauth/token. Validates the internal auth code (SHA-256 lookup + SELECT FOR UPDATE), checks nonce for CSRF, calls GetOrCreateUserByOAuth, generates JWT + refresh tokens, and stores the refresh token hash.
- **Migration 000007** — Adds provider user info columns (provider, provider_user_id, provider_email, provider_name, provider_email_verified) to oauth_authorization_codes.
- **Repository layer** — AuthorizationCodeInfo struct with extended columns, CreateAuthorizationCodeWithUserInfo using raw SQL.
- **Dependency wiring** — routes.go and router.go updated to pass *sql.DB and OAuth service dependencies.

### Security

- No JWT in redirect URLs — only opaque internal auth codes
- SHA-256 hashed storage of authorization codes
- SELECT FOR UPDATE + SERIALIZABLE isolation prevents concurrent redemption
- Nonce verification provides CSRF protection
- All error cases return same error to prevent timing oracles
- Codes marked as used even on failure (nonce mismatch, email exists)

### Testing

All 68 unit tests pass (10 new tests covering callback and token exchange). Only Docker-dependent integration tests fail (expected).

Closes #79
