### PR TITLE
feat(auth): add OAuth link init and set password endpoints

### DIFF
--- a/internal/database/sqlc/models.go
+++ b/internal/database/sqlc/models.go
@@ -29,14 +29,19 @@ type OauthAccount struct {
 }
 
 type OauthAuthorizationCode struct {
-	ID        uuid.UUID     `json:"id"`
-	CodeHash  string        `json:"code_hash"`
-	UserID    uuid.NullUUID `json:"user_id"`
-	Nonce     string        `json:"nonce"`
-	Purpose   string        `json:"purpose"`
-	ExpiresAt time.Time     `json:"expires_at"`
-	UsedAt    sql.NullTime  `json:"used_at"`
-	CreatedAt sql.NullTime  `json:"created_at"`
+	ID                    uuid.UUID     `json:"id"`
+	CodeHash              string        `json:"code_hash"`
+	UserID                uuid.NullUUID `json:"user_id"`
+	Nonce                 string        `json:"nonce"`
+	Purpose               string        `json:"purpose"`
+	ExpiresAt             time.Time     `json:"expires_at"`
+	UsedAt                sql.NullTime  `json:"used_at"`
+	CreatedAt             sql.NullTime  `json:"created_at"`
+	Provider              string        `json:"provider"`
+	ProviderUserID        string        `json:"provider_user_id"`
+	ProviderEmail         string        `json:"provider_email"`
+	ProviderName          string        `json:"provider_name"`
+	ProviderEmailVerified bool          `json:"provider_email_verified"`
 }
 
 type PasswordResetToken struct {

--- a/internal/database/sqlc/oauth_authorization_codes.sql.go
+++ b/internal/database/sqlc/oauth_authorization_codes.sql.go
@@ -16,7 +16,7 @@ import (
 const createAuthorizationCode = `-- name: CreateAuthorizationCode :one
 INSERT INTO oauth_authorization_codes (id, code_hash, user_id, nonce, purpose, expires_at, created_at)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at
+RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified
 `
 
 type CreateAuthorizationCodeParams struct {
@@ -49,6 +49,11 @@ func (q *Queries) CreateAuthorizationCode(ctx context.Context, arg CreateAuthori
 		&i.ExpiresAt,
 		&i.UsedAt,
 		&i.CreatedAt,
+		&i.Provider,
+		&i.ProviderUserID,
+		&i.ProviderEmail,
+		&i.ProviderName,
+		&i.ProviderEmailVerified,
 	)
 	return i, err
 }
@@ -56,7 +61,7 @@ func (q *Queries) CreateAuthorizationCode(ctx context.Context, arg CreateAuthori
 const deleteAuthorizationCode = `-- name: DeleteAuthorizationCode :one
 DELETE FROM oauth_authorization_codes
 WHERE id = $1
-RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at
+RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified
 `
 
 func (q *Queries) DeleteAuthorizationCode(ctx context.Context, id uuid.UUID) (OauthAuthorizationCode, error) {
@@ -71,6 +76,11 @@ func (q *Queries) DeleteAuthorizationCode(ctx context.Context, id uuid.UUID) (Oa
 		&i.ExpiresAt,
 		&i.UsedAt,
 		&i.CreatedAt,
+		&i.Provider,
+		&i.ProviderUserID,
+		&i.ProviderEmail,
+		&i.ProviderName,
+		&i.ProviderEmailVerified,
 	)
 	return i, err
 }
@@ -78,7 +88,7 @@ func (q *Queries) DeleteAuthorizationCode(ctx context.Context, id uuid.UUID) (Oa
 const deleteExpiredAuthorizationCodes = `-- name: DeleteExpiredAuthorizationCodes :many
 DELETE FROM oauth_authorization_codes
 WHERE expires_at < $1
-RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at
+RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified
 `
 
 func (q *Queries) DeleteExpiredAuthorizationCodes(ctx context.Context, expiresAt time.Time) ([]OauthAuthorizationCode, error) {
@@ -99,6 +109,11 @@ func (q *Queries) DeleteExpiredAuthorizationCodes(ctx context.Context, expiresAt
 			&i.ExpiresAt,
 			&i.UsedAt,
 			&i.CreatedAt,
+			&i.Provider,
+			&i.ProviderUserID,
+			&i.ProviderEmail,
+			&i.ProviderName,
+			&i.ProviderEmailVerified,
 		); err != nil {
 			return nil, err
 		}
@@ -114,7 +129,7 @@ func (q *Queries) DeleteExpiredAuthorizationCodes(ctx context.Context, expiresAt
 }
 
 const getAuthorizationCodeByHash = `-- name: GetAuthorizationCodeByHash :one
-SELECT id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at FROM oauth_authorization_codes
+SELECT id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified FROM oauth_authorization_codes
 WHERE code_hash = $1
 `
 
@@ -130,6 +145,42 @@ func (q *Queries) GetAuthorizationCodeByHash(ctx context.Context, codeHash strin
 		&i.ExpiresAt,
 		&i.UsedAt,
 		&i.CreatedAt,
+		&i.Provider,
+		&i.ProviderUserID,
+		&i.ProviderEmail,
+		&i.ProviderName,
+		&i.ProviderEmailVerified,
+	)
+	return i, err
+}
+
+const getAuthorizationCodeByNonceAndPurpose = `-- name: GetAuthorizationCodeByNonceAndPurpose :one
+SELECT id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified FROM oauth_authorization_codes
+WHERE nonce = $1 AND purpose = $2
+`
+
+type GetAuthorizationCodeByNonceAndPurposeParams struct {
+	Nonce   string `json:"nonce"`
+	Purpose string `json:"purpose"`
+}
+
+func (q *Queries) GetAuthorizationCodeByNonceAndPurpose(ctx context.Context, arg GetAuthorizationCodeByNonceAndPurposeParams) (OauthAuthorizationCode, error) {
+	row := q.db.QueryRowContext(ctx, getAuthorizationCodeByNonceAndPurpose, arg.Nonce, arg.Purpose)
+	var i OauthAuthorizationCode
+	err := row.Scan(
+		&i.ID,
+		&i.CodeHash,
+		&i.UserID,
+		&i.Nonce,
+		&i.Purpose,
+		&i.ExpiresAt,
+		&i.UsedAt,
+		&i.CreatedAt,
+		&i.Provider,
+		&i.ProviderUserID,
+		&i.ProviderEmail,
+		&i.ProviderName,
+		&i.ProviderEmailVerified,
 	)
 	return i, err
 }
@@ -138,7 +189,7 @@ const markAuthorizationCodeAsUsed = `-- name: MarkAuthorizationCodeAsUsed :one
 UPDATE oauth_authorization_codes
 SET used_at = NOW()
 WHERE code_hash = $1 AND used_at IS NULL
-RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at
+RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified
 `
 
 func (q *Queries) MarkAuthorizationCodeAsUsed(ctx context.Context, codeHash string) (OauthAuthorizationCode, error) {
@@ -153,6 +204,11 @@ func (q *Queries) MarkAuthorizationCodeAsUsed(ctx context.Context, codeHash stri
 		&i.ExpiresAt,
 		&i.UsedAt,
 		&i.CreatedAt,
+		&i.Provider,
+		&i.ProviderUserID,
+		&i.ProviderEmail,
+		&i.ProviderName,
+		&i.ProviderEmailVerified,
 	)
 	return i, err
 }

--- a/internal/database/sqlc/queries/oauth_authorization_codes.sql
+++ b/internal/database/sqlc/queries/oauth_authorization_codes.sql
@@ -22,3 +22,7 @@ RETURNING *;
 DELETE FROM oauth_authorization_codes
 WHERE id = $1
 RETURNING *;
+
+-- name: GetAuthorizationCodeByNonceAndPurpose :one
+SELECT * FROM oauth_authorization_codes
+WHERE nonce = $1 AND purpose = $2;

--- a/internal/features/auth/dto/oauth.go
+++ b/internal/features/auth/dto/oauth.go
@@ -161,19 +161,49 @@ type ProvidersResponse struct {
 	Providers []OAuthProviderInfo `json:"providers"`
 }
 
+// OAuthLinkInitInput represents the input for initiating an OAuth link flow.
+// This endpoint is authenticated — the Authorization header contains the Bearer token.
+type OAuthLinkInitInput struct {
+	Authorization string `header:"Authorization"`
+	Provider      string `path:"provider" doc:"OAuth provider identifier (e.g., google)"`
+}
+
+// OAuthLinkInitResponse represents the response for initiating an OAuth link flow.
+type OAuthLinkInitResponse struct {
+	Body struct {
+		State string `json:"state" doc:"Base64-encoded state with purpose=link"`
+	}
+}
+
+// SetPasswordInput represents the input for setting a password for an OAuth-only user.
+// This endpoint is authenticated — the Authorization header contains the Bearer token.
+type SetPasswordInput struct {
+	Authorization string `header:"Authorization"`
+	Body          struct {
+		Password string `json:"password" minLength:"8" doc:"New password (8+ chars, 1 uppercase, 1 lowercase, 1 number)"`
+	}
+}
+
+// SetPasswordOutput represents the output for setting a password.
+type SetPasswordOutput struct {
+	Body struct {
+		Message string `json:"message" doc:"Success message"`
+	}
+}
+
 // InitiateOAuthInput represents the input for initiating OAuth login.
 // Path parameter: provider - the OAuth provider name (e.g., "google")
 // Query parameter: state - the OAuth state parameter from the client
 type InitiateOAuthInput struct {
-	Provider string `path:"provider"` // OAuth provider identifier
-	State    string `query:"state"` // OAuth state parameter (required, non-empty)
+	Provider string `path:"provider" doc:"OAuth provider identifier (e.g., google)"` // OAuth provider identifier
+	State    string `query:"state"`                                                  // OAuth state parameter (required, non-empty)
 }
 
 // InitiateOAuthOutput represents the output for initiating OAuth login.
 // Returns a 302 redirect to the provider's authorization URL.
 type InitiateOAuthOutput struct {
 	Location string `header:"Location"` // Redirect URL
-	Status   int    `status:"302"`     // HTTP redirect status code
+	Status   int    `status:"302"`      // HTTP redirect status code
 }
 
 // OAuthCallbackInput represents the input for OAuth callback.
@@ -181,15 +211,15 @@ type InitiateOAuthOutput struct {
 // Query parameters: code - authorization code, state - OAuth state parameter
 type OAuthCallbackInput struct {
 	Provider string `path:"provider"` // OAuth provider identifier
-	Code     string `query:"code"`   // Authorization code from provider
-	State    string `query:"state"`  // OAuth state parameter
-	Error    string `query:"error"`  // Error from provider (if any)
+	Code     string `query:"code"`    // Authorization code from provider
+	State    string `query:"state"`   // OAuth state parameter
+	Error    string `query:"error"`   // Error from provider (if any)
 }
 
 // OAuthCallbackOutput represents the output for OAuth callback.
 type OAuthCallbackOutput struct {
 	Redirect string `header:"Location"` // Redirect URL after callback
-	Status   int    `status:"302"`     // HTTP redirect status code
+	Status   int    `status:"302"`      // HTTP redirect status code
 }
 
 // ParseOAuthState parses the OAuth state from a string.

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -192,3 +192,41 @@ func (m *MockOAuthAuthorizationCodeRepository) CleanupExpiredAuthorizationCodes(
 	args := m.Called(ctx)
 	return args.Error(0)
 }
+
+func (m *MockOAuthAuthorizationCodeRepository) GetAuthorizationCodeByNonceAndPurpose(ctx context.Context, nonce, purpose string) (db.OauthAuthorizationCode, error) {
+	args := m.Called(ctx, nonce, purpose)
+	return args.Get(0).(db.OauthAuthorizationCode), args.Error(1)
+}
+
+// -- User repository mock (needed for set-password handler) --
+
+var _ repository.UserRepository = (*MockUserRepository)(nil)
+
+type MockUserRepository struct {
+	mock.Mock
+}
+
+func (m *MockUserRepository) CreateUser(ctx context.Context, email, displayName, passwordHash string, emailVerified bool) (db.CreateUserRow, error) {
+	args := m.Called(ctx, email, displayName, passwordHash, emailVerified)
+	return args.Get(0).(db.CreateUserRow), args.Error(1)
+}
+
+func (m *MockUserRepository) GetUserByEmail(ctx context.Context, email string) (db.User, error) {
+	args := m.Called(ctx, email)
+	return args.Get(0).(db.User), args.Error(1)
+}
+
+func (m *MockUserRepository) GetUserByID(ctx context.Context, id string) (db.User, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(db.User), args.Error(1)
+}
+
+func (m *MockUserRepository) UpdatePassword(ctx context.Context, id, passwordHash string) error {
+	args := m.Called(ctx, id, passwordHash)
+	return args.Error(0)
+}
+
+func (m *MockUserRepository) VerifyEmail(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
 	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
@@ -135,6 +136,18 @@ func RegisterOAuthProviderRoutes(api huma.API, authCodeRepo repository.OAuthAuth
 		Summary:     "Exchange OAuth authorization code for JWT tokens",
 		Tags:        []string{"auth"},
 	}, TokenExchangeHandler(deps))
+
+	// Initiate OAuth link - authenticated
+	huma.Register(api, huma.Operation{
+		OperationID: "oauth-link-init",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/oauth/{provider}/init",
+		Summary:     "Initiate OAuth provider linking",
+		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
+	}, OAuthLinkInitHandler(deps))
 }
 
 // isValidRedirect checks if the redirect URL is a relative path or a trusted domain.
@@ -358,6 +371,138 @@ func handleProviderError(input *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutpu
 	return &dto.OAuthCallbackOutput{
 		Redirect: redirectURL,
 	}, nil
+}
+
+// extractUserIDFromAuth extracts the authenticated user ID from the Authorization header.
+// It parses the Bearer token, validates it, and returns the user ID from the "sub" claim.
+func extractUserIDFromAuth(authHeader string, tokenSvc service.TokenServiceInterface) (uuid.UUID, error) {
+	if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
+		return uuid.Nil, huma.Error401Unauthorized("Invalid authorization header", nil)
+	}
+	tokenString := authHeader[7:]
+
+	claims, err := tokenSvc.ValidateAccessToken(tokenString)
+	if err != nil {
+		return uuid.Nil, huma.Error401Unauthorized("Invalid or expired access token", err)
+	}
+
+	userIDStr, ok := claims["sub"].(string)
+	if !ok {
+		return uuid.Nil, huma.Error401Unauthorized("Invalid access token", nil)
+	}
+
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return uuid.Nil, huma.Error401Unauthorized("Invalid user ID in token", nil)
+	}
+
+	if userID == uuid.Nil {
+		return uuid.Nil, huma.Error401Unauthorized("Invalid user ID", nil)
+	}
+
+	return userID, nil
+}
+
+// OAuthLinkInitHandler returns a handler that initiates an OAuth account linking flow.
+// POST /api/auth/oauth/{provider}/init (authenticated)
+//
+// This stores an authorization code binding the authenticated user to a nonce with
+// purpose="link", so the OAuth callback flow can associate the provider account
+// with the correct user.
+func OAuthLinkInitHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthLinkInitInput) (*dto.OAuthLinkInitResponse, error) {
+	return func(ctx context.Context, input *dto.OAuthLinkInitInput) (*dto.OAuthLinkInitResponse, error) {
+		// Extract authenticated user ID from Bearer token
+		userID, err := extractUserIDFromAuth(input.Authorization, deps.TokenSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		// Verify the provider exists
+		_, err = oauth.GetProvider(input.Provider)
+		if err != nil {
+			return nil, huma.Error404NotFound("provider not found", err)
+		}
+
+		// Generate a cryptographically random nonce
+		nonceBytes := make([]byte, 16)
+		if _, err := rand.Read(nonceBytes); err != nil {
+			return nil, huma.Error500InternalServerError("failed to generate nonce", err)
+		}
+		nonce := hex.EncodeToString(nonceBytes)
+
+		// Create state with purpose="link" (no redirect needed for linking)
+		state := dto.OAuthState{
+			Nonce:    nonce,
+			Redirect: "",
+			Purpose:  "link",
+		}
+		encodedState := state.Encode()
+
+		// Store authorization code binding user_id to this nonce.
+		// The code_hash uses the encoded state hash as a placeholder since
+		// no provider auth code exists yet. The callback handler MUST use
+		// GetAuthorizationCodeByNonceAndPurpose (not GetAuthorizationCodeByHash)
+		// to find this record, since code_hash is a placeholder, not the provider code.
+		codeID := uuid.New()
+		codeHash := hashCode(encodedState)
+		expiresAt := time.Now().Add(oauthAuthCodeExpiry)
+
+		_, err = deps.AuthCodeRepo.CreateAuthorizationCode(
+			ctx,
+			codeID,
+			codeHash,
+			uuid.NullUUID{UUID: userID, Valid: true},
+			nonce,
+			"link",
+			expiresAt,
+		)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to store authorization code", err)
+		}
+
+		return &dto.OAuthLinkInitResponse{
+			Body: struct {
+				State string `json:"state" doc:"Base64-encoded state with purpose=link"`
+			}{State: encodedState},
+		}, nil
+	}
+}
+
+// SetPasswordHandler returns a handler that sets a password for an OAuth-only user.
+// POST /api/auth/password/set (authenticated)
+//
+// This allows users who registered via OAuth to add a password, enabling
+// password-based login and preventing lock-out when unlinking providers.
+func SetPasswordHandler(userRepo repository.UserRepository, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.SetPasswordInput) (*dto.SetPasswordOutput, error) {
+	return func(ctx context.Context, input *dto.SetPasswordInput) (*dto.SetPasswordOutput, error) {
+		// Extract authenticated user ID from Bearer token
+		userID, err := extractUserIDFromAuth(input.Authorization, tokenSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		// Validate password strength
+		if err := ValidatePassword(input.Body.Password); err != nil {
+			return nil, huma.Error400BadRequest("invalid password", err)
+		}
+
+		// Hash the password
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(input.Body.Password), service.BcryptCost)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to hash password", err)
+		}
+
+		// Update the user's password
+		if err := userRepo.UpdatePassword(ctx, userID.String(), string(hashedPassword)); err != nil {
+			return nil, huma.Error500InternalServerError("failed to set password", err)
+		}
+
+		return &dto.SetPasswordOutput{
+			Body: struct {
+				Message string `json:"message" doc:"Success message"`
+			}{Message: "password set successfully"},
+		}, nil
+	}
 }
 
 // generateAuthCode creates a cryptographically random authorization code and its SHA-256 hash.

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	db "github.com/shuvo-paul/medminder/internal/database/sqlc"
 	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
@@ -524,4 +526,224 @@ func TestTokenExchangeHandler_MalformedState(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
+}
+
+// -- OAuth Link Init Handler Tests --
+
+func newLinkInitDeps() *handlers.OAuthHandlerDeps {
+	return &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: &MockOAuthAuthorizationCodeRepository{},
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+	}
+}
+
+func TestOAuthLinkInitHandler_Success(t *testing.T) {
+	// Register a mock provider for link init to verify against
+	os.Setenv("LINK_TEST_ID", "test-id")
+	os.Setenv("LINK_TEST_SECRET", "test-secret")
+	os.Setenv("LINK_TEST_REDIRECT", "http://localhost:8080/callback")
+	defer func() {
+		os.Unsetenv("LINK_TEST_ID")
+		os.Unsetenv("LINK_TEST_SECRET")
+		os.Unsetenv("LINK_TEST_REDIRECT")
+	}()
+
+	mockProvider := &oauth.MockProvider{
+		NameVal:            "http://link.test",
+		RequiredEnvVarsVal: []string{"LINK_TEST_ID", "LINK_TEST_SECRET", "LINK_TEST_REDIRECT"},
+	}
+	err := oauth.Register(mockProvider)
+	require.NoError(t, err, "failed to register mock provider")
+
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	deps := newLinkInitDeps()
+	mockTokenSvc := deps.TokenSvc.(*MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockCodeRepo := deps.AuthCodeRepo.(*MockOAuthAuthorizationCodeRepository)
+	mockCodeRepo.On("CreateAuthorizationCode",
+		mock.Anything,
+		mock.AnythingOfType("uuid.UUID"),     // id
+		mock.AnythingOfType("string"),        // codeHash
+		mock.AnythingOfType("uuid.NullUUID"), // userID
+		mock.AnythingOfType("string"),        // nonce
+		"link",                               // purpose
+		mock.AnythingOfType("time.Time"),     // expiresAt
+	).Return(db.OauthAuthorizationCode{}, nil)
+
+	handler := handlers.OAuthLinkInitHandler(deps)
+
+	input := &dto.OAuthLinkInitInput{
+		Authorization: "Bearer " + token,
+		Provider:      "http://link.test",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify state contains purpose=link
+	state, err := dto.ParseOAuthState(resp.Body.State)
+	require.NoError(t, err)
+	assert.Equal(t, "link", state.Purpose)
+	assert.NotEmpty(t, state.Nonce)
+}
+
+func TestOAuthLinkInitHandler_MissingAuth(t *testing.T) {
+	deps := newLinkInitDeps()
+	handler := handlers.OAuthLinkInitHandler(deps)
+
+	input := &dto.OAuthLinkInitInput{
+		Authorization: "",
+		Provider:      "google",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "Invalid authorization header")
+}
+
+func TestOAuthLinkInitHandler_InvalidToken(t *testing.T) {
+	deps := newLinkInitDeps()
+	mockTokenSvc := deps.TokenSvc.(*MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", "bad-token").Return(nil, service.ErrInvalidToken)
+
+	handler := handlers.OAuthLinkInitHandler(deps)
+
+	input := &dto.OAuthLinkInitInput{
+		Authorization: "Bearer bad-token",
+		Provider:      "google",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "Invalid or expired")
+}
+
+func TestOAuthLinkInitHandler_ProviderNotFound(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	deps := newLinkInitDeps()
+	mockTokenSvc := deps.TokenSvc.(*MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	handler := handlers.OAuthLinkInitHandler(deps)
+
+	input := &dto.OAuthLinkInitInput{
+		Authorization: "Bearer " + token,
+		Provider:      "unknown-provider",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "provider not found")
+}
+
+// -- Set Password Handler Tests --
+
+func TestSetPasswordHandler_Success(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockUserRepo := new(MockUserRepository)
+	// UpdatePassword is called with the user ID string and a bcrypt-hashed password
+	mockUserRepo.On("UpdatePassword", mock.Anything, userID.String(), mock.AnythingOfType("string")).Return(nil)
+
+	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+
+	input := &dto.SetPasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.Password = "SecurePass1"
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "password set successfully", resp.Body.Message)
+	mockUserRepo.AssertExpectations(t)
+}
+
+func TestSetPasswordHandler_InvalidToken(t *testing.T) {
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", "bad-token").Return(nil, service.ErrInvalidToken)
+
+	mockUserRepo := new(MockUserRepository)
+
+	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+
+	input := &dto.SetPasswordInput{
+		Authorization: "Bearer bad-token",
+	}
+	input.Body.Password = "SecurePass1"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "Invalid or expired")
+}
+
+func TestSetPasswordHandler_WeakPassword(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockUserRepo := new(MockUserRepository)
+
+	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+
+	input := &dto.SetPasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.Password = "short" // Too short, no uppercase, no digit
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "invalid password")
+	// Verify UpdatePassword was never called
+	mockUserRepo.AssertNotCalled(t, "UpdatePassword", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestSetPasswordHandler_UpdateFailed(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockUserRepo := new(MockUserRepository)
+	mockUserRepo.On("UpdatePassword", mock.Anything, userID.String(), mock.AnythingOfType("string")).Return(assert.AnError)
+
+	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+
+	input := &dto.SetPasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.Password = "SecurePass1"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to set password")
 }

--- a/internal/features/auth/repository/oauth_repository.go
+++ b/internal/features/auth/repository/oauth_repository.go
@@ -36,6 +36,7 @@ type OAuthAuthorizationCodeRepository interface {
 	CreateAuthorizationCode(ctx context.Context, id uuid.UUID, codeHash string, userID uuid.NullUUID, nonce string, purpose string, expiresAt time.Time) (db.OauthAuthorizationCode, error)
 	CreateAuthorizationCodeWithUserInfo(ctx context.Context, id uuid.UUID, codeHash string, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error)
 	GetAuthorizationCodeByHash(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error)
+	GetAuthorizationCodeByNonceAndPurpose(ctx context.Context, nonce, purpose string) (db.OauthAuthorizationCode, error)
 	GetAndLockAuthorizationCode(ctx context.Context, codeHash string) (*AuthorizationCodeInfo, error)
 	MarkAuthorizationCodeAsUsed(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error)
 	CleanupExpiredAuthorizationCodes(ctx context.Context) error
@@ -122,6 +123,7 @@ func (r *oauthAuthorizationCodeRepository) CreateAuthorizationCode(ctx context.C
 		Nonce:     nonce,
 		Purpose:   purpose,
 		ExpiresAt: expiresAt,
+		CreatedAt: sql.NullTime{Time: time.Now(), Valid: true},
 	})
 }
 
@@ -147,6 +149,25 @@ func (r *oauthAuthorizationCodeRepository) CreateAuthorizationCodeWithUserInfo(c
 
 func (r *oauthAuthorizationCodeRepository) GetAuthorizationCodeByHash(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error) {
 	code, err := r.queries.GetAuthorizationCodeByHash(ctx, codeHash)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.OauthAuthorizationCode{}, ErrOAuthCodeNotFound
+		}
+		return db.OauthAuthorizationCode{}, err
+	}
+	return code, nil
+}
+
+// GetAuthorizationCodeByNonceAndPurpose looks up an authorization code by its nonce and purpose.
+// Used by the link flow to correlate callback codes with init records.
+//
+// NOTE: This method does not check expires_at or used_at. Callers are responsible
+// for validating expiry and usage state after retrieval.
+func (r *oauthAuthorizationCodeRepository) GetAuthorizationCodeByNonceAndPurpose(ctx context.Context, nonce, purpose string) (db.OauthAuthorizationCode, error) {
+	code, err := r.queries.GetAuthorizationCodeByNonceAndPurpose(ctx, db.GetAuthorizationCodeByNonceAndPurposeParams{
+		Nonce:   nonce,
+		Purpose: purpose,
+	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return db.OauthAuthorizationCode{}, ErrOAuthCodeNotFound

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -90,4 +90,16 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, jwtSecret
 
 	// OAuth provider routes (unauthenticated)
 	handlers.RegisterOAuthProviderRoutes(api, oauthAuthCodeRepo, oauthSvc, tokenSvc, tokenRepo)
+
+	// Set password (authenticated) — for OAuth-only users to add a password
+	huma.Register(api, huma.Operation{
+		OperationID: "set-password",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/password/set",
+		Summary:     "Set a password for an OAuth-only user",
+		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
+	}, handlers.SetPasswordHandler(userRepo, tokenSvc))
 }


### PR DESCRIPTION
## Summary

Two new authenticated endpoints for Issue #81:

1. **`POST /api/auth/oauth/{provider}/init`** — Initiate OAuth account linking flow
2. **`POST /api/auth/password/set`** — Set password for OAuth-only users

## Changes

| File | Change |
|------|--------|
| `dto/oauth.go` | Added 4 DTOs, added `doc` tag to InitiateOAuthInput for consistency |
| `handlers/oauth_providers.go` | Added `extractUserIDFromAuth` helper, OAuthLinkInitHandler, SetPasswordHandler, route registration |
| `handlers/oauth_providers_test.go` | 8 tests covering happy path, auth errors, validation, repo failure |
| `handlers/mocks_test.go` | Added MockUserRepository with compile-time interface check |
| `repository/oauth_repository.go` | Fixed CreateAuthorizationCode CreatedAt=NULL bug. Added GetAuthorizationCodeByNonceAndPurpose. |
| `routes.go` | Registered set-password route |
| `sqlc models/queries` | Regenerated with provider columns. Added GetAuthorizationCodeByNonceAndPurpose query. |

## Testing

All 8 tests pass. Full auth feature suite passes.

## Design Notes

- **Minimal scope**: Only the two endpoints. Callback/token exchange changes for completing the link flow are left for a follow-up.
- **code_hash placeholder**: Uses hashCode(encodedState) since DB has NOT NULL, but no provider code exists at init time.
- **Pattern consistency**: extractUserIDFromAuth matches the pattern from resend_verification.go and logout.go.

Close #81 