### PR TITLE
fix: backend codebase improvements (correctness, duplication, consistency)

### DIFF
--- a/internal/common/database/container_test.go
+++ b/internal/common/database/container_test.go
@@ -1,162 +1,14 @@
 package database_test
 
 import (
-	"context"
-	"database/sql"
-	"fmt"
-	"net/url"
 	"testing"
-	"time"
 
-	"github.com/shuvo-paul/medminder/internal/common/config"
-	"github.com/shuvo-paul/medminder/internal/common/database"
-	"github.com/shuvo-paul/medminder/internal/common/database/migrations"
+	"github.com/shuvo-paul/medminder/internal/common/database/testutil"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
-type TestContainer struct {
-	Container *postgres.PostgresContainer
-	Config    config.DatabaseConfig
-	ConnStr   string
-}
-
-func SetupPostgresContainer(t *testing.T) *TestContainer {
-	t.Helper()
-
-	ctx := context.Background()
-
-	pgContainer, err := postgres.Run(ctx,
-		"postgres:18-alpine",
-		postgres.WithDatabase("medminder"),
-		postgres.WithUsername("medminder"),
-		postgres.WithPassword("medminder"),
-	)
-	require.NoError(t, err, "should start postgres container")
-
-	connStr, err := pgContainer.ConnectionString(ctx)
-	require.NoError(t, err, "should get connection string")
-
-	cfg, err := parseDSN(connStr)
-	require.NoError(t, err, "should parse DSN")
-
-	return &TestContainer{
-		Container: pgContainer,
-		Config:    cfg,
-		ConnStr:   connStr,
-	}
-}
-
-func parseDSN(connStr string) (config.DatabaseConfig, error) {
-	u, err := url.Parse(connStr)
-	if err != nil {
-		return config.DatabaseConfig{}, fmt.Errorf("failed to parse DSN: %w", err)
-	}
-
-	port := 5432
-	if p := u.Port(); p != "" {
-		fmt.Sscanf(p, "%d", &port)
-	}
-
-	dbName := u.Path
-	if dbName != "" && dbName[0] == '/' {
-		dbName = dbName[1:]
-	}
-
-	password, hasPassword := u.User.Password()
-	if !hasPassword {
-		password = ""
-	}
-
-	return config.DatabaseConfig{
-		Host:     u.Hostname(),
-		Port:     port,
-		User:     u.User.Username(),
-		Password: password,
-		Name:     dbName,
-		SSLMode:  false,
-	}, nil
-}
-
-func (tc *TestContainer) Connect(t *testing.T) *sql.DB {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	var db *sql.DB
-	var err error
-
-	for i := 0; i < 10; i++ {
-		select {
-		case <-ctx.Done():
-			require.NoError(t, ctx.Err(), "timeout connecting to database")
-			return nil
-		default:
-		}
-
-		db, err = database.Connect(tc.Config)
-		if err == nil {
-			return db
-		}
-		if i < 9 {
-			time.Sleep(500 * time.Millisecond)
-		}
-	}
-	require.NoError(t, err, "should connect to database")
-	return db
-}
-
-func (tc *TestContainer) NewMigrator(t *testing.T) *database.Migrator {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	var m *database.Migrator
-	var err error
-
-	for i := 0; i < 10; i++ {
-		select {
-		case <-ctx.Done():
-			require.NoError(t, ctx.Err(), "timeout creating migrator")
-			return nil
-		default:
-		}
-
-		m, err = database.NewMigratorWithFS(
-			migrations.FS,
-			tc.Config.Host,
-			tc.Config.Port,
-			tc.Config.User,
-			tc.Config.Password,
-			tc.Config.Name,
-			tc.Config.SSLMode,
-		)
-		if err == nil {
-			return m
-		}
-		if i < 9 {
-			time.Sleep(500 * time.Millisecond)
-		}
-	}
-	require.NoError(t, err, "should create migrator")
-	return m
-}
-
-func (tc *TestContainer) Teardown(t *testing.T) {
-	t.Helper()
-
-	if tc.Container != nil {
-		err := tc.Container.Terminate(context.Background())
-		if err != nil {
-			t.Logf("failed to terminate container: %v", err)
-		}
-	}
-}
-
 func TestContainerExists(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	db := tc.Connect(t)
@@ -169,7 +21,7 @@ func TestContainerExists(t *testing.T) {
 }
 
 func TestContainerWithMigrations(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	m := tc.NewMigrator(t)

--- a/internal/common/database/db_test.go
+++ b/internal/common/database/db_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/shuvo-paul/medminder/internal/common/config"
 	"github.com/shuvo-paul/medminder/internal/common/database"
+	"github.com/shuvo-paul/medminder/internal/common/database/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConnect(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	db := tc.Connect(t)

--- a/internal/common/database/migrate.go
+++ b/internal/common/database/migrate.go
@@ -14,9 +14,17 @@ type Migrator struct {
 	m *migrate.Migrate
 }
 
+func buildDSN(host string, port int, user, password, dbname string, sslmode bool) string {
+	sslModeStr := "disable"
+	if sslmode {
+		sslModeStr = "require"
+	}
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+		user, password, host, port, dbname, sslModeStr)
+}
+
 func NewMigratorFromConfig(sourceURL, host string, port int, user, password, dbname string, sslmode bool) (*Migrator, error) {
-	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		user, password, host, port, dbname, map[bool]string{true: "require", false: "disable"}[sslmode])
+	dsn := buildDSN(host, port, user, password, dbname, sslmode)
 
 	m, err := migrate.New(sourceURL, dsn)
 	if err != nil {
@@ -27,8 +35,7 @@ func NewMigratorFromConfig(sourceURL, host string, port int, user, password, dbn
 }
 
 func NewMigratorWithFS(fsys fs.FS, host string, port int, user, password, dbname string, sslmode bool) (*Migrator, error) {
-	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
-		user, password, host, port, dbname, map[bool]string{true: "require", false: "disable"}[sslmode])
+	dsn := buildDSN(host, port, user, password, dbname, sslmode)
 
 	source, err := iofs.New(fsys, ".")
 	if err != nil {

--- a/internal/common/database/migrate_test.go
+++ b/internal/common/database/migrate_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/shuvo-paul/medminder/internal/common/database"
 	"github.com/shuvo-paul/medminder/internal/common/database/migrations"
+	"github.com/shuvo-paul/medminder/internal/common/database/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewMigrator(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	m := tc.NewMigrator(t)
@@ -23,7 +24,7 @@ func TestNewMigrator_InvalidDSN(t *testing.T) {
 }
 
 func TestMigrator_Up(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	m := tc.NewMigrator(t)
@@ -32,7 +33,7 @@ func TestMigrator_Up(t *testing.T) {
 }
 
 func TestMigrator_Down(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	m := tc.NewMigrator(t)
@@ -44,7 +45,7 @@ func TestMigrator_Down(t *testing.T) {
 }
 
 func TestMigrator_Steps(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	m := tc.NewMigrator(t)
@@ -53,7 +54,7 @@ func TestMigrator_Steps(t *testing.T) {
 }
 
 func TestMigrator_Force(t *testing.T) {
-	tc := SetupPostgresContainer(t)
+	tc := testutil.SetupPostgresContainer(t)
 	defer tc.Teardown(t)
 
 	m := tc.NewMigrator(t)

--- a/internal/features/auth/handlers/logout.go
+++ b/internal/features/auth/handlers/logout.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/google/uuid"
 	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 )
@@ -14,29 +13,9 @@ import (
 // the Authorization header and delegates logout to AuthService.
 func LogoutHandler(authSvc service.AuthService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.LogoutInput) (*dto.LogoutOutput, error) {
 	return func(ctx context.Context, input *dto.LogoutInput) (*dto.LogoutOutput, error) {
-		authHeader := input.Authorization
-		if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
-			return nil, huma.Error401Unauthorized("Invalid authorization header", nil)
-		}
-		tokenString := authHeader[7:]
-
-		claims, err := tokenSvc.ValidateAccessToken(tokenString)
+		userID, err := ExtractUserIDFromAuth(input.Authorization, tokenSvc)
 		if err != nil {
-			return nil, huma.Error401Unauthorized("Invalid or expired access token", err)
-		}
-
-		userIDStr, ok := claims["sub"].(string)
-		if !ok {
-			return nil, huma.Error401Unauthorized("Invalid access token", nil)
-		}
-
-		userID, err := uuid.Parse(userIDStr)
-		if err != nil {
-			return nil, huma.Error401Unauthorized("Invalid user ID in token", nil)
-		}
-
-		if userID == uuid.Nil {
-			return nil, huma.Error401Unauthorized("Invalid user ID", nil)
+			return nil, err
 		}
 
 		if err := authSvc.Logout(ctx, userID); err != nil {

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -38,6 +38,11 @@ func (m *MockAuthService) Logout(ctx context.Context, userID uuid.UUID) error {
 	return args.Error(0)
 }
 
+func (m *MockAuthService) SetPassword(ctx context.Context, userID uuid.UUID, password string) error {
+	args := m.Called(ctx, userID, password)
+	return args.Error(0)
+}
+
 type MockTokenService struct {
 	mock.Mock
 }
@@ -147,11 +152,6 @@ func (m *MockRefreshTokenRepository) DeleteRefreshToken(ctx context.Context, id 
 }
 
 func (m *MockRefreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
-	args := m.Called(ctx, userID)
-	return args.Error(0)
-}
-
-func (m *MockRefreshTokenRepository) DeleteAllForUser(ctx context.Context, userID uuid.UUID) error {
 	args := m.Called(ctx, userID)
 	return args.Error(0)
 }

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/google/uuid"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/shuvo-paul/medminder/internal/common/log"
 	auditRepo "github.com/shuvo-paul/medminder/internal/features/audit/repository"
@@ -409,9 +408,9 @@ func handleProviderError(input *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutpu
 	}, nil
 }
 
-// extractUserIDFromAuth extracts the authenticated user ID from the Authorization header.
+// ExtractUserIDFromAuth extracts the authenticated user ID from the Authorization header.
 // It parses the Bearer token, validates it, and returns the user ID from the "sub" claim.
-func extractUserIDFromAuth(authHeader string, tokenSvc service.TokenServiceInterface) (uuid.UUID, error) {
+func ExtractUserIDFromAuth(authHeader string, tokenSvc service.TokenServiceInterface) (uuid.UUID, error) {
 	if len(authHeader) < 7 || authHeader[:7] != "Bearer " {
 		return uuid.Nil, huma.Error401Unauthorized("Invalid authorization header", nil)
 	}
@@ -448,7 +447,7 @@ func extractUserIDFromAuth(authHeader string, tokenSvc service.TokenServiceInter
 func OAuthLinkInitHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthLinkInitInput) (*dto.OAuthLinkInitResponse, error) {
 	return func(ctx context.Context, input *dto.OAuthLinkInitInput) (*dto.OAuthLinkInitResponse, error) {
 		// Extract authenticated user ID from Bearer token
-		userID, err := extractUserIDFromAuth(input.Authorization, deps.TokenSvc)
+		userID, err := ExtractUserIDFromAuth(input.Authorization, deps.TokenSvc)
 		if err != nil {
 			return nil, err
 		}
@@ -509,27 +508,18 @@ func OAuthLinkInitHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 //
 // This allows users who registered via OAuth to add a password, enabling
 // password-based login and preventing lock-out when unlinking providers.
-func SetPasswordHandler(userRepo repository.UserRepository, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.SetPasswordInput) (*dto.SetPasswordOutput, error) {
+func SetPasswordHandler(authSvc service.AuthService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.SetPasswordInput) (*dto.SetPasswordOutput, error) {
 	return func(ctx context.Context, input *dto.SetPasswordInput) (*dto.SetPasswordOutput, error) {
-		// Extract authenticated user ID from Bearer token
-		userID, err := extractUserIDFromAuth(input.Authorization, tokenSvc)
+		userID, err := ExtractUserIDFromAuth(input.Authorization, tokenSvc)
 		if err != nil {
 			return nil, err
 		}
 
-		// Validate password strength
 		if err := ValidatePassword(input.Body.Password); err != nil {
 			return nil, huma.Error400BadRequest("invalid password", err)
 		}
 
-		// Hash the password
-		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(input.Body.Password), service.BcryptCost)
-		if err != nil {
-			return nil, huma.Error500InternalServerError("failed to hash password", err)
-		}
-
-		// Update the user's password
-		if err := userRepo.UpdatePassword(ctx, userID.String(), string(hashedPassword)); err != nil {
+		if err := authSvc.SetPassword(ctx, userID, input.Body.Password); err != nil {
 			return nil, huma.Error500InternalServerError("failed to set password", err)
 		}
 

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -680,11 +680,10 @@ func TestSetPasswordHandler_Success(t *testing.T) {
 	mockTokenSvc := new(MockTokenService)
 	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
 
-	mockUserRepo := new(MockUserRepository)
-	// UpdatePassword is called with the user ID string and a bcrypt-hashed password
-	mockUserRepo.On("UpdatePassword", mock.Anything, userID.String(), mock.AnythingOfType("string")).Return(nil)
+	mockAuthSvc := new(MockAuthService)
+	mockAuthSvc.On("SetPassword", mock.Anything, userID, mock.AnythingOfType("string")).Return(nil)
 
-	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+	handler := handlers.SetPasswordHandler(mockAuthSvc, mockTokenSvc)
 
 	input := &dto.SetPasswordInput{
 		Authorization: "Bearer " + token,
@@ -696,16 +695,16 @@ func TestSetPasswordHandler_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "password set successfully", resp.Body.Message)
-	mockUserRepo.AssertExpectations(t)
+	mockAuthSvc.AssertExpectations(t)
 }
 
 func TestSetPasswordHandler_InvalidToken(t *testing.T) {
 	mockTokenSvc := new(MockTokenService)
 	mockTokenSvc.On("ValidateAccessToken", "bad-token").Return(nil, service.ErrInvalidToken)
 
-	mockUserRepo := new(MockUserRepository)
+	mockAuthSvc := new(MockAuthService)
 
-	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+	handler := handlers.SetPasswordHandler(mockAuthSvc, mockTokenSvc)
 
 	input := &dto.SetPasswordInput{
 		Authorization: "Bearer bad-token",
@@ -726,9 +725,9 @@ func TestSetPasswordHandler_WeakPassword(t *testing.T) {
 	mockTokenSvc := new(MockTokenService)
 	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
 
-	mockUserRepo := new(MockUserRepository)
+	mockAuthSvc := new(MockAuthService)
 
-	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+	handler := handlers.SetPasswordHandler(mockAuthSvc, mockTokenSvc)
 
 	input := &dto.SetPasswordInput{
 		Authorization: "Bearer " + token,
@@ -740,8 +739,8 @@ func TestSetPasswordHandler_WeakPassword(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "invalid password")
-	// Verify UpdatePassword was never called
-	mockUserRepo.AssertNotCalled(t, "UpdatePassword", mock.Anything, mock.Anything, mock.Anything)
+	// Verify SetPassword was never called
+	mockAuthSvc.AssertNotCalled(t, "SetPassword", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestSetPasswordHandler_UpdateFailed(t *testing.T) {
@@ -751,10 +750,10 @@ func TestSetPasswordHandler_UpdateFailed(t *testing.T) {
 	mockTokenSvc := new(MockTokenService)
 	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
 
-	mockUserRepo := new(MockUserRepository)
-	mockUserRepo.On("UpdatePassword", mock.Anything, userID.String(), mock.AnythingOfType("string")).Return(assert.AnError)
+	mockAuthSvc := new(MockAuthService)
+	mockAuthSvc.On("SetPassword", mock.Anything, userID, mock.AnythingOfType("string")).Return(assert.AnError)
 
-	handler := handlers.SetPasswordHandler(mockUserRepo, mockTokenSvc)
+	handler := handlers.SetPasswordHandler(mockAuthSvc, mockTokenSvc)
 
 	input := &dto.SetPasswordInput{
 		Authorization: "Bearer " + token,

--- a/internal/features/auth/handlers/password_reset.go
+++ b/internal/features/auth/handlers/password_reset.go
@@ -44,14 +44,14 @@ func RegisterPasswordResetRoutes(api huma.API, deps PasswordResetDeps) {
 		Tags:        []string{"auth"},
 	}, func(ctx context.Context, input *dto.PasswordResetConfirmInput) (*dto.PasswordResetConfirmOutput, error) {
 		if err := ValidatePassword(input.Body.NewPassword); err != nil {
-			return nil, huma.NewError(http.StatusBadRequest, err.Error())
+			return nil, huma.Error400BadRequest("invalid password", err)
 		}
 
 		if err := deps.Svc.ConfirmReset(ctx, input.Body.Token, input.Body.NewPassword); err != nil {
 			if errors.Is(err, repository.ErrTokenNotFound) ||
 				errors.Is(err, repository.ErrTokenExpired) ||
 				errors.Is(err, repository.ErrTokenUsed) {
-				return nil, huma.NewError(http.StatusBadRequest, "Invalid or expired token")
+				return nil, huma.Error400BadRequest("Invalid or expired token", err)
 			}
 			return nil, err
 		}

--- a/internal/features/auth/repository/refresh_token_repository.go
+++ b/internal/features/auth/repository/refresh_token_repository.go
@@ -13,7 +13,6 @@ type RefreshTokenRepository interface {
 	GetRefreshTokenByHash(ctx context.Context, tokenHash string) (db.RefreshToken, error)
 	DeleteRefreshToken(ctx context.Context, id uuid.UUID) error
 	DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error
-	DeleteAllForUser(ctx context.Context, userID uuid.UUID) error
 }
 
 type refreshTokenRepository struct {
@@ -41,9 +40,5 @@ func (r *refreshTokenRepository) DeleteRefreshToken(ctx context.Context, id uuid
 }
 
 func (r *refreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
-	return r.queries.DeleteUserRefreshTokens(ctx, userID)
-}
-
-func (r *refreshTokenRepository) DeleteAllForUser(ctx context.Context, userID uuid.UUID) error {
 	return r.queries.DeleteUserRefreshTokens(ctx, userID)
 }

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -102,5 +102,5 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, auditRepo
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
-	}, handlers.SetPasswordHandler(userRepo, tokenSvc))
+	}, handlers.SetPasswordHandler(authSvc, tokenSvc))
 }

--- a/internal/features/auth/service/auth_service.go
+++ b/internal/features/auth/service/auth_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,6 +37,7 @@ type AuthService interface {
 	Register(ctx context.Context, email, displayName, password string) (*RegisterResult, error)
 	Login(ctx context.Context, email, password string) (*LoginResult, error)
 	Logout(ctx context.Context, userID uuid.UUID) error
+	SetPassword(ctx context.Context, userID uuid.UUID, password string) error
 }
 
 type authService struct {
@@ -43,6 +45,8 @@ type authService struct {
 	tokenRepo repository.RefreshTokenRepository
 	tokenSvc  TokenServiceInterface
 }
+
+var _ AuthService = (*authService)(nil)
 
 func NewAuthService(userRepo repository.UserRepository, tokenRepo repository.RefreshTokenRepository, tokenSvc TokenServiceInterface) *authService {
 	return &authService{
@@ -131,6 +135,19 @@ func (s *authService) Logout(ctx context.Context, userID uuid.UUID) error {
 
 	if err := s.tokenRepo.DeleteUserRefreshTokens(ctx, userID); err != nil {
 		return errors.Join(ErrLogoutFailed, err)
+	}
+
+	return nil
+}
+
+func (s *authService) SetPassword(ctx context.Context, userID uuid.UUID, password string) error {
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
+	if err != nil {
+		return fmt.Errorf("hashing password: %w", err)
+	}
+
+	if err := s.userRepo.UpdatePassword(ctx, userID.String(), string(hashedPassword)); err != nil {
+		return fmt.Errorf("updating password: %w", err)
 	}
 
 	return nil

--- a/internal/features/auth/service/auth_service_test.go
+++ b/internal/features/auth/service/auth_service_test.go
@@ -74,11 +74,6 @@ func (m *MockRefreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context
 	return args.Error(0)
 }
 
-func (m *MockRefreshTokenRepository) DeleteAllForUser(ctx context.Context, userID uuid.UUID) error {
-	args := m.Called(ctx, userID)
-	return args.Error(0)
-}
-
 // MockTokenService mocks service.TokenServiceInterface
 type MockTokenService struct {
 	mock.Mock

--- a/internal/features/auth/service/email_verification_service.go
+++ b/internal/features/auth/service/email_verification_service.go
@@ -46,6 +46,8 @@ type emailVerificationService struct {
 	frontendURL string
 }
 
+var _ EmailVerificationService = (*emailVerificationService)(nil)
+
 // NewEmailVerificationService creates a new EmailVerificationService.
 func NewEmailVerificationService(
 	userRepo repository.UserRepository,

--- a/internal/features/auth/service/oauth_service.go
+++ b/internal/features/auth/service/oauth_service.go
@@ -30,6 +30,8 @@ type oauthService struct {
 	auditRepo        auditRepo.AuditRepository
 }
 
+var _ OAuthService = (*oauthService)(nil)
+
 func NewOAuthService(userRepo repository.UserRepository, oauthAccountRepo repository.OAuthAccountRepository, auditRepository auditRepo.AuditRepository) OAuthService {
 	return &oauthService{
 		userRepo:         userRepo,

--- a/internal/features/auth/service/password_reset_service.go
+++ b/internal/features/auth/service/password_reset_service.go
@@ -8,12 +8,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
 	emailclient "github.com/shuvo-paul/medminder/internal/common/email"
+	"github.com/shuvo-paul/medminder/internal/common/log"
 	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
 )
 
@@ -35,6 +35,8 @@ type passwordResetService struct {
 	emailClient      emailclient.EmailClient
 	frontendURL      string
 }
+
+var _ PasswordResetService = (*passwordResetService)(nil)
 
 // NewPasswordResetService creates a new PasswordResetService.
 func NewPasswordResetService(
@@ -91,9 +93,9 @@ func (s *passwordResetService) RequestReset(ctx context.Context, email string) e
 	resetLink := fmt.Sprintf("%s/auth/reset-password?token=%s", s.frontendURL, token)
 	emailBody := fmt.Sprintf("<p>Click <a href=\"%s\">here</a> to reset your password. This link expires in 1 hour.</p>", resetLink)
 	if err := s.emailClient.SendEmail(ctx, user.Email, "MedMinder Password Reset", emailBody); err != nil {
-		log.Printf("failed to send password reset email, cleaning up token: %v", err)
+		log.Warn("failed to send password reset email, cleaning up token", log.F("error", err.Error()))
 		if cleanupErr := s.tokenRepo.DeleteAllForUser(ctx, user.ID); cleanupErr != nil {
-			log.Printf("failed to cleanup token after email failure: %v", cleanupErr)
+			log.Warn("failed to cleanup token after email failure", log.F("error", cleanupErr.Error()))
 		}
 		// Return nil to prevent email enumeration - user sees success message anyway
 		return nil
@@ -138,8 +140,8 @@ func (s *passwordResetService) ConfirmReset(ctx context.Context, token, newPassw
 		return fmt.Errorf("updating password: %w", err)
 	}
 
-	if err := s.refreshTokenRepo.DeleteAllForUser(ctx, user.ID); err != nil {
-		log.Printf("failed to delete refresh tokens: %v", err)
+	if err := s.refreshTokenRepo.DeleteUserRefreshTokens(ctx, user.ID); err != nil {
+		log.Warn("failed to delete refresh tokens", log.F("error", err.Error()))
 	}
 
 	return nil

--- a/internal/features/auth/service/password_reset_service_test.go
+++ b/internal/features/auth/service/password_reset_service_test.go
@@ -99,12 +99,12 @@ func (m *MockPRPasswordResetTokenRepository) DeleteAllForUser(ctx context.Contex
 // MockPRRefreshTokenRepository
 
 type MockPRRefreshTokenRepository struct {
-	DeleteAllForUserFn func(ctx context.Context, userID uuid.UUID) error
+	DeleteUserRefreshTokensFn func(ctx context.Context, userID uuid.UUID) error
 }
 
-func (m *MockPRRefreshTokenRepository) DeleteAllForUser(ctx context.Context, userID uuid.UUID) error {
-	if m.DeleteAllForUserFn != nil {
-		return m.DeleteAllForUserFn(ctx, userID)
+func (m *MockPRRefreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
+	if m.DeleteUserRefreshTokensFn != nil {
+		return m.DeleteUserRefreshTokensFn(ctx, userID)
 	}
 	return nil
 }
@@ -117,9 +117,6 @@ func (m *MockPRRefreshTokenRepository) GetRefreshTokenByHash(ctx context.Context
 	return db.RefreshToken{}, nil
 }
 func (m *MockPRRefreshTokenRepository) DeleteRefreshToken(ctx context.Context, id uuid.UUID) error {
-	return nil
-}
-func (m *MockPRRefreshTokenRepository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
 	return nil
 }
 
@@ -300,7 +297,7 @@ func TestPasswordResetService_ConfirmReset(t *testing.T) {
 				userRepo.UpdatePasswordFn = func(ctx context.Context, id, passwordHash string) error {
 					return nil
 				}
-				refreshTokenRepo.DeleteAllForUserFn = func(ctx context.Context, userID uuid.UUID) error {
+				refreshTokenRepo.DeleteUserRefreshTokensFn = func(ctx context.Context, userID uuid.UUID) error {
 					return nil
 				}
 			},

--- a/internal/features/auth/service/token.go
+++ b/internal/features/auth/service/token.go
@@ -27,6 +27,8 @@ type TokenService struct {
 	jwtSecret []byte
 }
 
+var _ TokenServiceInterface = (*TokenService)(nil)
+
 type TokenServiceInterface interface {
 	GenerateAccessToken(userID uuid.UUID, email string) (string, error)
 	GenerateRefreshToken() (string, error)
@@ -51,11 +53,23 @@ func (ts *TokenService) GenerateAccessToken(userID uuid.UUID, email string) (str
 }
 
 func (ts *TokenService) GenerateRefreshToken() (string, error) {
-	return GenerateRefreshToken()
+	bytes := make([]byte, refreshTokenByteSize)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate random token: %w", err)
+	}
+	return hex.EncodeToString(bytes), nil
 }
 
 func (ts *TokenService) HashRefreshToken(token string) string {
-	return HashRefreshToken(token)
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}
+
+func (ts *TokenService) VerifyRefreshToken(token, hash string) error {
+	if ts.HashRefreshToken(token) != hash {
+		return ErrInvalidToken
+	}
+	return nil
 }
 
 func (ts *TokenService) ValidateAccessToken(tokenString string) (jwt.MapClaims, error) {
@@ -85,65 +99,4 @@ func (ts *TokenService) ValidateAccessToken(tokenString string) (jwt.MapClaims, 
 	}
 
 	return claims, nil
-}
-
-func GenerateAccessToken(userID uuid.UUID, email, jwtSecret string) (string, error) {
-	claims := jwt.MapClaims{
-		"sub":   userID.String(),
-		"email": email,
-		"exp":   time.Now().Add(AccessTokenExpiry).Unix(),
-		"iat":   time.Now().Unix(),
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString([]byte(jwtSecret))
-}
-
-func ValidateAccessToken(tokenString, jwtSecret string) (jwt.MapClaims, error) {
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-		return []byte(jwtSecret), nil
-	})
-
-	if err != nil {
-		return nil, ErrInvalidToken
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok || !token.Valid {
-		return nil, ErrInvalidToken
-	}
-
-	exp, ok := claims["exp"].(float64)
-	if !ok {
-		return nil, ErrInvalidToken
-	}
-
-	if time.Now().Unix() > int64(exp) {
-		return nil, ErrTokenExpired
-	}
-
-	return claims, nil
-}
-
-func GenerateRefreshToken() (string, error) {
-	bytes := make([]byte, refreshTokenByteSize)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", fmt.Errorf("failed to generate random token: %w", err)
-	}
-	return hex.EncodeToString(bytes), nil
-}
-
-func HashRefreshToken(token string) string {
-	hash := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(hash[:])
-}
-
-func VerifyRefreshToken(token, hash string) error {
-	if HashRefreshToken(token) != hash {
-		return ErrInvalidToken
-	}
-	return nil
 }

--- a/internal/features/auth/service/token_test.go
+++ b/internal/features/auth/service/token_test.go
@@ -71,31 +71,35 @@ func TestAccessTokenExpiry(t *testing.T) {
 }
 
 func TestGenerateRefreshToken(t *testing.T) {
-	token, err := service.GenerateRefreshToken()
+	tokenSvc := service.NewTokenService(testJWTSecret)
+	token, err := tokenSvc.GenerateRefreshToken()
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	assert.Len(t, token, 64, "refresh token should be 64 characters (32 bytes hex)")
 }
 
 func TestHashRefreshToken(t *testing.T) {
+	tokenSvc := service.NewTokenService(testJWTSecret)
 	token := "abc123"
-	hash := service.HashRefreshToken(token)
+	hash := tokenSvc.HashRefreshToken(token)
 	assert.NotEqual(t, token, hash)
 	assert.Len(t, hash, 64)
 }
 
 func TestVerifyRefreshToken(t *testing.T) {
+	tokenSvc := service.NewTokenService(testJWTSecret)
 	token := "abc123"
-	hash := service.HashRefreshToken(token)
+	hash := tokenSvc.HashRefreshToken(token)
 
-	err := service.VerifyRefreshToken(token, hash)
+	err := tokenSvc.VerifyRefreshToken(token, hash)
 	assert.NoError(t, err)
 }
 
 func TestVerifyRefreshToken_Invalid(t *testing.T) {
+	tokenSvc := service.NewTokenService(testJWTSecret)
 	token := "abc123"
-	hash := service.HashRefreshToken(token)
+	hash := tokenSvc.HashRefreshToken(token)
 
-	err := service.VerifyRefreshToken("wrongtoken", hash)
+	err := tokenSvc.VerifyRefreshToken("wrongtoken", hash)
 	assert.Error(t, err)
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"database/sql"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -64,7 +65,7 @@ func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, func(),
 	auditRepo := repository.NewAuditRepository(queries)
 
 	emailClient := email.NewEmailClient(cfg.Email)
-	email.StartEmailQueue(emailClient, 3, nil)
+	email.StartEmailQueue(emailClient, 3, slog.Default())
 
 	auth.RegisterRoutes(api, dbConn, queries, auditRepo, cfg.JWT.Secret, emailClient, cfg.FrontendURL)
 


### PR DESCRIPTION
## Summary

Fixes and improvements from a comprehensive codebase review of `internal/`.

### Critical fix
- **Nil logger in email queue** (`router.go`): `nil` *slog.Logger passed to `StartEmailQueue` would panic on send failure → use `slog.Default()`

### High priority
- **Token validation dedup**: Exported `ExtractUserIDFromAuth` helper, eliminated duplicate Bearer parsing in `logout.go`
- **SetPassword through service layer**: Moved bcrypt hashing + repo call from handler into `AuthService.SetPassword`

### Medium
- **Dead token functions**: Removed standalone `GenerateAccessToken`, `ValidateAccessToken`, etc. — inlined into `TokenService` methods
- **Consistent logging**: `log.Printf` → `log.Warn` with structured fields in `password_reset_service`
- **Consistent huma errors**: `huma.NewError` → `huma.Error400BadRequest` in `password_reset.go`

### Low
- **Remove `DeleteAllForUser` alias**: Redundant `RefreshTokenRepository` method — all callers use `DeleteUserRefreshTokens`
- **Interface compliance checks**: `var _ Interface = (*Impl)(nil)` on all service structs
- **DSN helper extraction**: `buildDSN` shared between `NewMigratorFromConfig` and `NewMigratorWithFS`
- **Test container dedup**: `container_test.go` delegated to `testutil` package, removed 140+ lines of duplication

### Verification
```
go test ./...   # all pass
go vet ./...    # clean
go build ./...  # clean
```