### PR TITLE
fix(auth): Google OAuth flow fixes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/shuvo-paul/medminder/internal/common/database/migrations"
 	"github.com/shuvo-paul/medminder/internal/common/log"
 	"github.com/shuvo-paul/medminder/internal/router"
+	"github.com/shuvo-paul/medminder/pkg/oauth"
+	"github.com/shuvo-paul/medminder/pkg/oauth/google"
 )
 
 //go:embed all:web/dist
@@ -28,6 +30,13 @@ func main() {
 	if err != nil {
 		log.Error("failed to load config", log.F("error", err.Error()))
 		return
+	}
+
+	// Register OAuth providers (env vars must be available — loaded by godotenv above)
+	if googleProvider, err := google.New(); err == nil {
+		if err := oauth.Register(googleProvider); err != nil {
+			log.Warn("google OAuth provider not available", log.F("reason", err.Error()))
+		}
 	}
 
 	configureLogger(cfg.AppEnv)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,14 +32,14 @@ func main() {
 		return
 	}
 
+	configureLogger(cfg.AppEnv)
+
 	// Register OAuth providers (env vars must be available — loaded by godotenv above)
 	if googleProvider, err := google.New(); err == nil {
 		if err := oauth.Register(googleProvider); err != nil {
 			log.Warn("google OAuth provider not available", log.F("reason", err.Error()))
 		}
 	}
-
-	configureLogger(cfg.AppEnv)
 
 	migrator, err := database.NewMigratorWithFS(migrations.FS,
 		cfg.Database.Host,

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,12 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.12.0
 	github.com/phuslu/log v1.0.122
+	github.com/sqlc-dev/pqtype v0.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.41.0
 	github.com/wneessen/go-mail v0.7.2
 	golang.org/x/crypto v0.49.0
+	golang.org/x/text v0.35.0
 )
 
 require (
@@ -57,7 +59,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/sqlc-dev/pqtype v0.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/testcontainers/testcontainers-go v0.41.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
@@ -70,7 +71,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/grpc v1.79.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/common/database/migrations/000005_create_oauth_accounts.up.sql
+++ b/internal/common/database/migrations/000005_create_oauth_accounts.up.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS oauth_accounts (
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     provider VARCHAR(50) NOT NULL,
     provider_user_id VARCHAR(255) NOT NULL,
-    connected_at TIMESTAMPTZ DEFAULT NOW(),
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 

--- a/internal/database/sqlc/models.go
+++ b/internal/database/sqlc/models.go
@@ -35,7 +35,6 @@ type OauthAccount struct {
 	UserID         uuid.UUID    `json:"user_id"`
 	Provider       string       `json:"provider"`
 	ProviderUserID string       `json:"provider_user_id"`
-	ConnectedAt    sql.NullTime `json:"connected_at"`
 	CreatedAt      sql.NullTime `json:"created_at"`
 }
 

--- a/internal/database/sqlc/oauth_accounts.sql.go
+++ b/internal/database/sqlc/oauth_accounts.sql.go
@@ -13,9 +13,9 @@ import (
 )
 
 const createOAuthAccount = `-- name: CreateOAuthAccount :one
-INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, connected_at, created_at)
-VALUES ($1, $2, $3, $4, $5, $6)
-RETURNING id, user_id, provider, provider_user_id, connected_at, created_at
+INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, created_at)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, user_id, provider, provider_user_id, created_at
 `
 
 type CreateOAuthAccountParams struct {
@@ -23,7 +23,6 @@ type CreateOAuthAccountParams struct {
 	UserID         uuid.UUID    `json:"user_id"`
 	Provider       string       `json:"provider"`
 	ProviderUserID string       `json:"provider_user_id"`
-	ConnectedAt    sql.NullTime `json:"connected_at"`
 	CreatedAt      sql.NullTime `json:"created_at"`
 }
 
@@ -33,7 +32,6 @@ func (q *Queries) CreateOAuthAccount(ctx context.Context, arg CreateOAuthAccount
 		arg.UserID,
 		arg.Provider,
 		arg.ProviderUserID,
-		arg.ConnectedAt,
 		arg.CreatedAt,
 	)
 	var i OauthAccount
@@ -42,7 +40,6 @@ func (q *Queries) CreateOAuthAccount(ctx context.Context, arg CreateOAuthAccount
 		&i.UserID,
 		&i.Provider,
 		&i.ProviderUserID,
-		&i.ConnectedAt,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -51,7 +48,7 @@ func (q *Queries) CreateOAuthAccount(ctx context.Context, arg CreateOAuthAccount
 const deleteOAuthAccount = `-- name: DeleteOAuthAccount :one
 DELETE FROM oauth_accounts
 WHERE id = $1
-RETURNING id, user_id, provider, provider_user_id, connected_at, created_at
+RETURNING id, user_id, provider, provider_user_id, created_at
 `
 
 func (q *Queries) DeleteOAuthAccount(ctx context.Context, id uuid.UUID) (OauthAccount, error) {
@@ -62,7 +59,6 @@ func (q *Queries) DeleteOAuthAccount(ctx context.Context, id uuid.UUID) (OauthAc
 		&i.UserID,
 		&i.Provider,
 		&i.ProviderUserID,
-		&i.ConnectedAt,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -84,7 +80,7 @@ func (q *Queries) DeleteOAuthAccountByUserIDAndProvider(ctx context.Context, arg
 }
 
 const getOAuthAccountByProviderAndUserID = `-- name: GetOAuthAccountByProviderAndUserID :one
-SELECT id, user_id, provider, provider_user_id, connected_at, created_at FROM oauth_accounts
+SELECT id, user_id, provider, provider_user_id, created_at FROM oauth_accounts
 WHERE provider = $1 AND provider_user_id = $2
 `
 
@@ -101,14 +97,13 @@ func (q *Queries) GetOAuthAccountByProviderAndUserID(ctx context.Context, arg Ge
 		&i.UserID,
 		&i.Provider,
 		&i.ProviderUserID,
-		&i.ConnectedAt,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
 const getOAuthAccountByUserIDAndProvider = `-- name: GetOAuthAccountByUserIDAndProvider :one
-SELECT id, user_id, provider, provider_user_id, connected_at, created_at FROM oauth_accounts
+SELECT id, user_id, provider, provider_user_id, created_at FROM oauth_accounts
 WHERE user_id = $1 AND provider = $2
 `
 
@@ -125,14 +120,13 @@ func (q *Queries) GetOAuthAccountByUserIDAndProvider(ctx context.Context, arg Ge
 		&i.UserID,
 		&i.Provider,
 		&i.ProviderUserID,
-		&i.ConnectedAt,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
 const getOAuthAccountsByUserID = `-- name: GetOAuthAccountsByUserID :many
-SELECT id, user_id, provider, provider_user_id, connected_at, created_at FROM oauth_accounts
+SELECT id, user_id, provider, provider_user_id, created_at FROM oauth_accounts
 WHERE user_id = $1
 `
 
@@ -150,7 +144,6 @@ func (q *Queries) GetOAuthAccountsByUserID(ctx context.Context, userID uuid.UUID
 			&i.UserID,
 			&i.Provider,
 			&i.ProviderUserID,
-			&i.ConnectedAt,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/internal/database/sqlc/queries/oauth_accounts.sql
+++ b/internal/database/sqlc/queries/oauth_accounts.sql
@@ -1,6 +1,6 @@
 -- name: CreateOAuthAccount :one
-INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, connected_at, created_at)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO oauth_accounts (id, user_id, provider, provider_user_id, created_at)
+VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: GetOAuthAccountByProviderAndUserID :one

--- a/internal/features/auth/dto/oauth.go
+++ b/internal/features/auth/dto/oauth.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 )
 
 // OAuthProvider represents an OAuth provider.
@@ -40,11 +39,19 @@ func (s *OAuthState) Encode() string {
 	return base64.URLEncoding.EncodeToString(data)
 }
 
-// DecodeOAuthState decodes a base64url-encoded OAuthState string.
+// DecodeOAuthState decodes a base64-encoded OAuthState string.
+// Accepts both standard base64 and base64url encodings.
 func DecodeOAuthState(encoded string) (*OAuthState, error) {
-	data, err := base64.URLEncoding.DecodeString(encoded)
+	if encoded == "" {
+		return nil, errors.New("invalid state: empty state parameter")
+	}
+
+	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return nil, fmt.Errorf("invalid state encoding: %w", err)
+		data, err = base64.URLEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("invalid state encoding: %w", err)
+		}
 	}
 
 	var state OAuthState
@@ -57,8 +64,10 @@ func DecodeOAuthState(encoded string) (*OAuthState, error) {
 
 // OAuthTokenRequest represents the request body for token exchange.
 type OAuthTokenRequest struct {
-	Code  string `json:"code" maxLength:"256"`   // authorization code
-	State string `json:"state" maxLength:"1024"` // base64url-encoded JSON: {nonce, redirect, purpose}
+	Body struct {
+		Code  string `json:"code" maxLength:"256"`   // authorization code
+		State string `json:"state" maxLength:"1024"` // base64url-encoded JSON: {nonce, redirect, purpose}
+	}
 }
 
 // OAuthTokenUserInfo represents user information in token response.
@@ -71,11 +80,13 @@ type OAuthTokenUserInfo struct {
 
 // OAuthTokenResponse represents the response for token exchange.
 type OAuthTokenResponse struct {
-	AccessToken  string             `json:"access_token"`
-	RefreshToken string             `json:"refresh_token"`
-	TokenType    string             `json:"token_type"` // "Bearer"
-	ExpiresIn    int                `json:"expires_in"` // 86400 (24h)
-	User         OAuthTokenUserInfo `json:"user"`
+	Body struct {
+		AccessToken  string             `json:"access_token"`
+		RefreshToken string             `json:"refresh_token"`
+		TokenType    string             `json:"token_type"` // "Bearer"
+		ExpiresIn    int                `json:"expires_in"` // 86400 (24h)
+		User         OAuthTokenUserInfo `json:"user"`
+	}
 }
 
 // OAuthInitInput represents the input for initiating OAuth link flow.
@@ -223,17 +234,6 @@ type OAuthCallbackOutput struct {
 }
 
 // ParseOAuthState parses the OAuth state from a string.
-// This is a convenience function that wraps DecodeOAuthState.
 func ParseOAuthState(stateStr string) (*OAuthState, error) {
-	// Handle URL encoding (replace - with + and _ with /)
-	stateStr = strings.ReplaceAll(stateStr, "-", "+")
-	stateStr = strings.ReplaceAll(stateStr, "_", "/")
-
-	// Add padding if needed
-	padding := 4 - len(stateStr)%4
-	if padding < 4 {
-		stateStr += strings.Repeat("=", padding)
-	}
-
 	return DecodeOAuthState(stateStr)
 }

--- a/internal/features/auth/dto/oauth.go
+++ b/internal/features/auth/dto/oauth.go
@@ -1,10 +1,9 @@
 package dto
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"errors"
-	"fmt"
+
+	"github.com/shuvo-paul/medminder/pkg/oauth"
 )
 
 // OAuthProvider represents an OAuth provider.
@@ -26,41 +25,10 @@ const (
 	OAuthErrorLinkFailed    OAuthErrorCode = "link_failed"
 )
 
-// OAuthState represents the state parameter in OAuth flows.
-type OAuthState struct {
-	Nonce    string `json:"nonce"`    // crypto.randomUUID() from client
-	Redirect string `json:"redirect"` // e.g., "/dashboard"
-	Purpose  string `json:"purpose"`  // "register" | "login" | "link"
-}
-
-// Encode encodes the OAuthState as a base64url-encoded string.
-func (s *OAuthState) Encode() string {
-	data, _ := json.Marshal(s)
-	return base64.URLEncoding.EncodeToString(data)
-}
-
-// DecodeOAuthState decodes a base64-encoded OAuthState string.
-// Accepts both standard base64 and base64url encodings.
-func DecodeOAuthState(encoded string) (*OAuthState, error) {
-	if encoded == "" {
-		return nil, errors.New("invalid state: empty state parameter")
-	}
-
-	data, err := base64.URLEncoding.DecodeString(encoded)
-	if err != nil {
-		data, err = base64.StdEncoding.DecodeString(encoded)
-		if err != nil {
-			return nil, fmt.Errorf("invalid state encoding: %w", err)
-		}
-	}
-
-	var state OAuthState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return nil, fmt.Errorf("invalid state JSON: %w", err)
-	}
-
-	return &state, nil
-}
+// OAuthState is the state parameter in OAuth flows.
+// It is a type alias for pkg/oauth.OAuthState so all encoding/decoding
+// logic lives in a single place.
+type OAuthState = oauth.OAuthState
 
 // OAuthTokenRequest represents the request body for token exchange.
 type OAuthTokenRequest struct {
@@ -78,15 +46,18 @@ type OAuthTokenUserInfo struct {
 	EmailVerified bool   `json:"email_verified"`
 }
 
+// OAuthTokenResponseBody is the JSON body of an OAuth token exchange response.
+type OAuthTokenResponseBody struct {
+	AccessToken  string             `json:"access_token"`
+	RefreshToken string             `json:"refresh_token"`
+	TokenType    string             `json:"token_type"` // "Bearer"
+	ExpiresIn    int                `json:"expires_in"` // 86400 (24h)
+	User         OAuthTokenUserInfo `json:"user"`
+}
+
 // OAuthTokenResponse represents the response for token exchange.
 type OAuthTokenResponse struct {
-	Body struct {
-		AccessToken  string             `json:"access_token"`
-		RefreshToken string             `json:"refresh_token"`
-		TokenType    string             `json:"token_type"` // "Bearer"
-		ExpiresIn    int                `json:"expires_in"` // 86400 (24h)
-		User         OAuthTokenUserInfo `json:"user"`
-	}
+	Body OAuthTokenResponseBody
 }
 
 // OAuthInitInput represents the input for initiating OAuth link flow.
@@ -235,5 +206,5 @@ type OAuthCallbackOutput struct {
 
 // ParseOAuthState parses the OAuth state from a string.
 func ParseOAuthState(stateStr string) (*OAuthState, error) {
-	return DecodeOAuthState(stateStr)
+	return oauth.DecodeOAuthState(stateStr)
 }

--- a/internal/features/auth/dto/oauth.go
+++ b/internal/features/auth/dto/oauth.go
@@ -46,9 +46,9 @@ func DecodeOAuthState(encoded string) (*OAuthState, error) {
 		return nil, errors.New("invalid state: empty state parameter")
 	}
 
-	data, err := base64.StdEncoding.DecodeString(encoded)
+	data, err := base64.URLEncoding.DecodeString(encoded)
 	if err != nil {
-		data, err = base64.URLEncoding.DecodeString(encoded)
+		data, err = base64.StdEncoding.DecodeString(encoded)
 		if err != nil {
 			return nil, fmt.Errorf("invalid state encoding: %w", err)
 		}

--- a/internal/features/auth/dto/oauth_test.go
+++ b/internal/features/auth/dto/oauth_test.go
@@ -35,6 +35,12 @@ func TestDecodeOAuthState(t *testing.T) {
 	assert.Equal(t, state.Purpose, decoded.Purpose)
 }
 
+func TestDecodeOAuthState_EmptyState(t *testing.T) {
+	_, err := DecodeOAuthState("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty state")
+}
+
 func TestDecodeOAuthState_InvalidEncoding(t *testing.T) {
 	_, err := DecodeOAuthState("not-valid-base64!!!")
 	assert.Error(t, err)

--- a/internal/features/auth/dto/oauth_test.go
+++ b/internal/features/auth/dto/oauth_test.go
@@ -19,42 +19,6 @@ func TestOAuthState_Encode(t *testing.T) {
 	assert.NotEqual(t, "test-nonce-123", encoded) // Should be base64 encoded
 }
 
-func TestDecodeOAuthState(t *testing.T) {
-	state := &OAuthState{
-		Nonce:    "test-nonce-123",
-		Redirect: "/dashboard",
-		Purpose:  "login",
-	}
-
-	encoded := state.Encode()
-	decoded, err := DecodeOAuthState(encoded)
-
-	require.NoError(t, err)
-	assert.Equal(t, state.Nonce, decoded.Nonce)
-	assert.Equal(t, state.Redirect, decoded.Redirect)
-	assert.Equal(t, state.Purpose, decoded.Purpose)
-}
-
-func TestDecodeOAuthState_EmptyState(t *testing.T) {
-	_, err := DecodeOAuthState("")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "empty state")
-}
-
-func TestDecodeOAuthState_InvalidEncoding(t *testing.T) {
-	_, err := DecodeOAuthState("not-valid-base64!!!")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid state encoding")
-}
-
-func TestDecodeOAuthState_InvalidJSON(t *testing.T) {
-	// Valid base64 but invalid JSON
-	encoded := "bm90LWpzb24=" // "not-json" in base64
-	_, err := DecodeOAuthState(encoded)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid state JSON")
-}
-
 func TestParseOAuthState(t *testing.T) {
 	state := &OAuthState{
 		Nonce:    "test-nonce",

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -391,13 +391,7 @@ func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 		}
 
 		return &dto.OAuthTokenResponse{
-			Body: struct {
-				AccessToken  string                 `json:"access_token"`
-				RefreshToken string                 `json:"refresh_token"`
-				TokenType    string                 `json:"token_type"`
-				ExpiresIn    int                    `json:"expires_in"`
-				User         dto.OAuthTokenUserInfo `json:"user"`
-			}{
+			Body: dto.OAuthTokenResponseBody{
 				AccessToken:  accessToken,
 				RefreshToken: refreshToken,
 				TokenType:    "Bearer",

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -110,6 +109,7 @@ func InitiateOAuthHandler() func(context.Context, *dto.InitiateOAuthInput) (*dto
 
 		return &dto.InitiateOAuthOutput{
 			Location: authURL,
+			Status:   http.StatusFound,
 		}, nil
 	}
 }
@@ -121,16 +121,18 @@ type OAuthHandlerDeps struct {
 	TokenSvc     service.TokenServiceInterface
 	TokenRepo    repository.RefreshTokenRepository
 	AuditRepo    auditRepo.AuditRepository
+	FrontendURL  string
 }
 
 // RegisterOAuthProviderRoutes registers the OAuth provider routes.
-func RegisterOAuthProviderRoutes(api huma.API, authCodeRepo repository.OAuthAuthorizationCodeRepository, oauthSvc service.OAuthService, tokenSvc service.TokenServiceInterface, tokenRepo repository.RefreshTokenRepository, auditRepository auditRepo.AuditRepository) {
+func RegisterOAuthProviderRoutes(api huma.API, authCodeRepo repository.OAuthAuthorizationCodeRepository, oauthSvc service.OAuthService, tokenSvc service.TokenServiceInterface, tokenRepo repository.RefreshTokenRepository, auditRepository auditRepo.AuditRepository, frontendURL string) {
 	deps := &OAuthHandlerDeps{
 		AuthCodeRepo: authCodeRepo,
 		OAuthSvc:     oauthSvc,
 		TokenSvc:     tokenSvc,
 		TokenRepo:    tokenRepo,
 		AuditRepo:    auditRepository,
+		FrontendURL:  frontendURL,
 	}
 
 	// List providers - unauthenticated
@@ -214,7 +216,7 @@ func OAuthCallbackHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 	return func(ctx context.Context, input *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutput, error) {
 		// --- Mode 1: Provider error ---
 		if input.Error != "" {
-			return handleProviderError(input)
+			return handleProviderError(input, deps.FrontendURL)
 		}
 
 		// --- Mode 2: Success (authorization code received) ---
@@ -226,7 +228,8 @@ func OAuthCallbackHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 		state, err := dto.ParseOAuthState(input.State)
 		if err != nil {
 			return &dto.OAuthCallbackOutput{
-				Redirect: "/auth/login?oauth_error=invalid_state",
+				Redirect: deps.FrontendURL + "/login?oauth_error=invalid_state",
+				Status:   http.StatusFound,
 			}, nil
 		}
 
@@ -273,20 +276,19 @@ func OAuthCallbackHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 			return nil, huma.Error500InternalServerError("failed to store authorization code", err)
 		}
 
-		// Encode original state to pass back to frontend
-		encodedState, err := json.Marshal(state)
-		if err != nil {
-			return nil, huma.Error500InternalServerError("failed to encode state", err)
-		}
+		// Encode original state base64url to pass back to frontend
+		encodedState := state.Encode()
 
 		// 302 redirect to frontend callback route (NO JWT tokens in URL)
-		redirectURL := fmt.Sprintf("/auth/callback?code=%s&state=%s",
+		redirectURL := fmt.Sprintf("%s/auth/callback?code=%s&state=%s",
+			deps.FrontendURL,
 			url.QueryEscape(internalCode),
-			url.QueryEscape(string(encodedState)),
+			url.QueryEscape(encodedState),
 		)
 
 		return &dto.OAuthCallbackOutput{
 			Redirect: redirectURL,
+			Status:   http.StatusFound,
 		}, nil
 	}
 }
@@ -297,13 +299,13 @@ func OAuthCallbackHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthTokenRequest) (*dto.OAuthTokenResponse, error) {
 	return func(ctx context.Context, input *dto.OAuthTokenRequest) (*dto.OAuthTokenResponse, error) {
 		// Parse and validate state
-		state, err := dto.ParseOAuthState(input.State)
+		state, err := dto.ParseOAuthState(input.Body.State)
 		if err != nil {
 			return nil, huma.Error401Unauthorized("invalid state", err)
 		}
 
 		// Hash the received code
-		codeHash := hashCode(input.Code)
+		codeHash := hashCode(input.Body.Code)
 
 		// Look up and lock the authorization code (prevents concurrent redemption)
 		authCodeInfo, err := deps.AuthCodeRepo.GetAndLockAuthorizationCode(ctx, codeHash)
@@ -338,24 +340,42 @@ func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 				return nil, huma.Error409Conflict(string(dto.OAuthErrorEmailExists),
 					fmt.Errorf("email already exists"))
 			}
+			log.Error("oauth_token_exchange_get_or_create_user_failed",
+				log.F("error", err.Error()),
+				log.F("provider", authCodeInfo.Provider),
+				log.F("provider_user_id", authCodeInfo.ProviderUserID),
+				log.F("provider_email", authCodeInfo.ProviderEmail),
+			)
 			return nil, huma.Error500InternalServerError("authentication failed", err)
 		}
 
 		// Mark authorization code as used (one-time use)
 		_, err = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
 		if err != nil {
+			log.Error("oauth_token_exchange_mark_code_used_failed",
+				log.F("error", err.Error()),
+				log.F("user_id", oauthUser.ID.String()),
+			)
 			return nil, huma.Error500InternalServerError("failed to mark code as used", err)
 		}
 
 		// Generate JWT access token
 		accessToken, err := deps.TokenSvc.GenerateAccessToken(oauthUser.ID, oauthUser.Email)
 		if err != nil {
+			log.Error("oauth_token_exchange_generate_access_token_failed",
+				log.F("error", err.Error()),
+				log.F("user_id", oauthUser.ID.String()),
+			)
 			return nil, huma.Error500InternalServerError("failed to generate access token", err)
 		}
 
 		// Generate refresh token
 		refreshToken, err := deps.TokenSvc.GenerateRefreshToken()
 		if err != nil {
+			log.Error("oauth_token_exchange_generate_refresh_token_failed",
+				log.F("error", err.Error()),
+				log.F("user_id", oauthUser.ID.String()),
+			)
 			return nil, huma.Error500InternalServerError("failed to generate refresh token", err)
 		}
 
@@ -363,19 +383,31 @@ func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 		refreshTokenHash := deps.TokenSvc.HashRefreshToken(refreshToken)
 		refreshExpiry := time.Now().Add(service.RefreshTokenExpiry)
 		if _, err := deps.TokenRepo.CreateRefreshToken(ctx, oauthUser.ID, refreshTokenHash, refreshExpiry); err != nil {
+			log.Error("oauth_token_exchange_store_refresh_token_failed",
+				log.F("error", err.Error()),
+				log.F("user_id", oauthUser.ID.String()),
+			)
 			return nil, huma.Error500InternalServerError("failed to store refresh token", err)
 		}
 
 		return &dto.OAuthTokenResponse{
-			AccessToken:  accessToken,
-			RefreshToken: refreshToken,
-			TokenType:    "Bearer",
-			ExpiresIn:    int(service.AccessTokenExpiry.Seconds()),
-			User: dto.OAuthTokenUserInfo{
-				ID:            oauthUser.ID.String(),
-				Email:         oauthUser.Email,
-				DisplayName:   oauthUser.DisplayName,
-				EmailVerified: oauthUser.EmailVerified,
+			Body: struct {
+				AccessToken  string                 `json:"access_token"`
+				RefreshToken string                 `json:"refresh_token"`
+				TokenType    string                 `json:"token_type"`
+				ExpiresIn    int                    `json:"expires_in"`
+				User         dto.OAuthTokenUserInfo `json:"user"`
+			}{
+				AccessToken:  accessToken,
+				RefreshToken: refreshToken,
+				TokenType:    "Bearer",
+				ExpiresIn:    int(service.AccessTokenExpiry.Seconds()),
+				User: dto.OAuthTokenUserInfo{
+					ID:            oauthUser.ID.String(),
+					Email:         oauthUser.Email,
+					DisplayName:   oauthUser.DisplayName,
+					EmailVerified: oauthUser.EmailVerified,
+				},
 			},
 		}, nil
 	}
@@ -384,27 +416,31 @@ func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 // handleProviderError handles the error case where the OAuth provider returned an error
 // (e.g., user denied access). It attempts to parse the state to redirect back to the
 // original frontend page, falling back to /login if state is absent or malformed.
-func handleProviderError(input *dto.OAuthCallbackInput) (*dto.OAuthCallbackOutput, error) {
+func handleProviderError(input *dto.OAuthCallbackInput, frontendURL string) (*dto.OAuthCallbackOutput, error) {
 	if input.State == "" {
 		return &dto.OAuthCallbackOutput{
-			Redirect: "/auth/login?oauth_error=cancelled",
+			Redirect: frontendURL + "/login?oauth_error=cancelled",
+			Status:   http.StatusFound,
 		}, nil
 	}
 
 	state, err := dto.ParseOAuthState(input.State)
 	if err != nil || state.Redirect == "" {
 		return &dto.OAuthCallbackOutput{
-			Redirect: "/auth/login?oauth_error=cancelled",
+			Redirect: frontendURL + "/login?oauth_error=cancelled",
+			Status:   http.StatusFound,
 		}, nil
 	}
 
-	redirectURL := fmt.Sprintf("%s?oauth_error=cancelled&provider=%s",
+	redirectURL := fmt.Sprintf("%s%s?oauth_error=cancelled&provider=%s",
+		frontendURL,
 		state.Redirect,
 		url.QueryEscape(input.Provider),
 	)
 
 	return &dto.OAuthCallbackOutput{
 		Redirect: redirectURL,
+		Status:   http.StatusFound,
 	}, nil
 }
 

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -126,6 +126,69 @@ func TestInitiateOAuthHandler_Success(t *testing.T) {
 	assert.Equal(t, "https://test-provider.example.com/auth", resp.Location)
 }
 
+func TestInitiateOAuthHandler_MissingState(t *testing.T) {
+	handler := handlers.InitiateOAuthHandler()
+
+	input := &dto.InitiateOAuthInput{
+		Provider: "google",
+		State:    "",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "state parameter is required")
+}
+
+func TestInitiateOAuthHandler_InvalidState(t *testing.T) {
+	handler := handlers.InitiateOAuthHandler()
+
+	input := &dto.InitiateOAuthInput{
+		Provider: "google",
+		State:    "not-valid-base64!!!",
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "invalid state parameter")
+}
+
+func TestInitiateOAuthHandler_OpenRedirect(t *testing.T) {
+	handler := handlers.InitiateOAuthHandler()
+
+	// Absolute URL with scheme — must be rejected as open redirect.
+	state := encodeOAuthState("test-nonce", "https://evil.example.com/steal", "login")
+	input := &dto.InitiateOAuthInput{
+		Provider: "google",
+		State:    state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "invalid redirect URL")
+}
+
+func TestInitiateOAuthHandler_ProviderNotFound(t *testing.T) {
+	handler := handlers.InitiateOAuthHandler()
+
+	state := encodeOAuthState("test-nonce", "/dashboard", "login")
+	input := &dto.InitiateOAuthInput{
+		Provider: "unknown-provider",
+		State:    state,
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "provider not found")
+}
+
 func TestOAuthCallbackHandler_ProviderError_WithState(t *testing.T) {
 	deps := newCallbackDeps()
 	handler := handlers.OAuthCallbackHandler(deps)

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -370,6 +370,7 @@ func TestTokenExchangeHandler_InvalidCode(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), string(dto.OAuthErrorInvalidCode))
 	auditRepo := deps.AuditRepo.(*MockAuditRepository)
 	auditRepo.AssertCalled(t, "LogEvent", mock.Anything, "oauth_code_rejected", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
@@ -417,6 +418,7 @@ func TestTokenExchangeHandler_NonceMismatch(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), string(dto.OAuthErrorInvalidCode))
 	mockCodeRepo.AssertCalled(t, "MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything)
 	auditRepo := deps.AuditRepo.(*MockAuditRepository)
 	auditRepo.AssertCalled(t, "LogEvent", mock.Anything, "oauth_code_rejected", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -467,6 +469,7 @@ func TestTokenExchangeHandler_EmailExists(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), string(dto.OAuthErrorEmailExists))
 	mockCodeRepo.AssertCalled(t, "MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything)
 	auditRepo := deps.AuditRepo.(*MockAuditRepository)
 	auditRepo.AssertCalled(t, "LogEvent", mock.Anything, "oauth_login_failed", mock.Anything, mock.Anything, mock.Anything, mock.Anything)

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -81,6 +80,18 @@ func newMockAuditRepo() *MockAuditRepository {
 	return m
 }
 
+// newCallbackDeps creates dependencies for testing the callback handler.
+func newCallbackDeps() *handlers.OAuthHandlerDeps {
+	return &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: &MockOAuthAuthorizationCodeRepository{},
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+		AuditRepo:    newMockAuditRepo(),
+		FrontendURL:  "http://localhost:5173",
+	}
+}
+
 func TestInitiateOAuthHandler_Success(t *testing.T) {
 	// Set required environment variables for the mock provider
 	os.Setenv("TEST_CLIENT_ID", "test-client-id")
@@ -115,89 +126,6 @@ func TestInitiateOAuthHandler_Success(t *testing.T) {
 	assert.Equal(t, "https://test-provider.example.com/auth", resp.Location)
 }
 
-func TestInitiateOAuthHandler_MissingState(t *testing.T) {
-	handler := handlers.InitiateOAuthHandler()
-
-	// Create input without state
-	input := &dto.InitiateOAuthInput{
-		Provider: "google",
-		State:    "",
-	}
-
-	// Call handler
-	resp, err := handler(context.Background(), input)
-
-	assert.Error(t, err)
-	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "state")
-}
-
-func TestInitiateOAuthHandler_InvalidState(t *testing.T) {
-	handler := handlers.InitiateOAuthHandler()
-
-	// Create input with invalid state (not base64 encoded)
-	input := &dto.InitiateOAuthInput{
-		Provider: "google",
-		State:    "not-valid-base64!!!",
-	}
-
-	// Call handler
-	resp, err := handler(context.Background(), input)
-
-	assert.Error(t, err)
-	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "invalid state")
-}
-
-func TestInitiateOAuthHandler_OpenRedirect(t *testing.T) {
-	handler := handlers.InitiateOAuthHandler()
-
-	// Create state with open redirect URL
-	state := encodeOAuthState("test-nonce", "https://evil.com/steal-token", "login")
-	input := &dto.InitiateOAuthInput{
-		Provider: "google",
-		State:    state,
-	}
-
-	// Call handler
-	resp, err := handler(context.Background(), input)
-
-	assert.Error(t, err)
-	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "redirect")
-}
-
-func TestInitiateOAuthHandler_ProviderNotFound(t *testing.T) {
-	handler := handlers.InitiateOAuthHandler()
-
-	// Create input with unknown provider and valid state
-	state := encodeOAuthState("test-nonce", "/dashboard", "login")
-	input := &dto.InitiateOAuthInput{
-		Provider: "unknown-provider",
-		State:    state,
-	}
-
-	// Call handler
-	resp, err := handler(context.Background(), input)
-
-	assert.Error(t, err)
-	assert.Nil(t, resp)
-	assert.True(t, strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "Provider not found"))
-}
-
-// -- OAuth Callback Handler Tests --
-
-// newCallbackDeps creates dependencies for testing the callback handler.
-func newCallbackDeps() *handlers.OAuthHandlerDeps {
-	return &handlers.OAuthHandlerDeps{
-		AuthCodeRepo: &MockOAuthAuthorizationCodeRepository{},
-		OAuthSvc:     &MockOAuthService{},
-		TokenSvc:     &MockTokenService{},
-		TokenRepo:    &MockRefreshTokenRepository{},
-		AuditRepo:    newMockAuditRepo(),
-	}
-}
-
 func TestOAuthCallbackHandler_ProviderError_WithState(t *testing.T) {
 	deps := newCallbackDeps()
 	handler := handlers.OAuthCallbackHandler(deps)
@@ -213,7 +141,7 @@ func TestOAuthCallbackHandler_ProviderError_WithState(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, "/dashboard?oauth_error=cancelled&provider=google", resp.Redirect)
+	assert.Equal(t, "http://localhost:5173/dashboard?oauth_error=cancelled&provider=google", resp.Redirect)
 }
 
 func TestOAuthCallbackHandler_ProviderError_EmptyState(t *testing.T) {
@@ -230,7 +158,7 @@ func TestOAuthCallbackHandler_ProviderError_EmptyState(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, "/auth/login?oauth_error=cancelled", resp.Redirect)
+	assert.Equal(t, "http://localhost:5173/login?oauth_error=cancelled", resp.Redirect)
 }
 
 func TestOAuthCallbackHandler_ProviderError_MalformedState(t *testing.T) {
@@ -247,7 +175,7 @@ func TestOAuthCallbackHandler_ProviderError_MalformedState(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, "/auth/login?oauth_error=cancelled", resp.Redirect)
+	assert.Equal(t, "http://localhost:5173/login?oauth_error=cancelled", resp.Redirect)
 }
 
 func TestOAuthCallbackHandler_MissingCode(t *testing.T) {
@@ -318,6 +246,7 @@ func TestOAuthCallbackHandler_Success(t *testing.T) {
 		TokenSvc:     &MockTokenService{},
 		TokenRepo:    &MockRefreshTokenRepository{},
 		AuditRepo:    newMockAuditRepo(),
+		FrontendURL:  "http://localhost:5173",
 	}
 	handler := handlers.OAuthCallbackHandler(deps)
 
@@ -332,7 +261,7 @@ func TestOAuthCallbackHandler_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Contains(t, resp.Redirect, "/auth/callback?code=")
+	assert.Contains(t, resp.Redirect, "http://localhost:5173/auth/callback?code=")
 	assert.Contains(t, resp.Redirect, "&state=")
 	// No JWT tokens in the redirect URL
 	assert.NotContains(t, resp.Redirect, "access_token")
@@ -392,20 +321,25 @@ func TestTokenExchangeHandler_Success(t *testing.T) {
 
 	state := encodeOAuthState("test-nonce-123", "/dashboard", "login")
 	input := &dto.OAuthTokenRequest{
-		Code:  rawCode,
-		State: state,
+		Body: struct {
+			Code  string `json:"code" maxLength:"256"`
+			State string `json:"state" maxLength:"1024"`
+		}{
+			Code:  rawCode,
+			State: state,
+		},
 	}
 
 	resp, err := handler(context.Background(), input)
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, "access-token-xyz", resp.AccessToken)
-	assert.Equal(t, "refresh-token-xyz", resp.RefreshToken)
-	assert.Equal(t, "Bearer", resp.TokenType)
-	assert.Equal(t, int(service.AccessTokenExpiry.Seconds()), resp.ExpiresIn)
-	assert.Equal(t, userID.String(), resp.User.ID)
-	assert.Equal(t, "test@example.com", resp.User.Email)
+	assert.Equal(t, "access-token-xyz", resp.Body.AccessToken)
+	assert.Equal(t, "refresh-token-xyz", resp.Body.RefreshToken)
+	assert.Equal(t, "Bearer", resp.Body.TokenType)
+	assert.Equal(t, int(service.AccessTokenExpiry.Seconds()), resp.Body.ExpiresIn)
+	assert.Equal(t, userID.String(), resp.Body.User.ID)
+	assert.Equal(t, "test@example.com", resp.Body.User.Email)
 }
 
 func TestTokenExchangeHandler_InvalidCode(t *testing.T) {
@@ -423,15 +357,19 @@ func TestTokenExchangeHandler_InvalidCode(t *testing.T) {
 
 	state := encodeOAuthState("test-nonce", "/dashboard", "login")
 	input := &dto.OAuthTokenRequest{
-		Code:  "invalid-code",
-		State: state,
+		Body: struct {
+			Code  string `json:"code" maxLength:"256"`
+			State string `json:"state" maxLength:"1024"`
+		}{
+			Code:  "invalid-code",
+			State: state,
+		},
 	}
 
 	resp, err := handler(context.Background(), input)
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), string(dto.OAuthErrorInvalidCode))
 	auditRepo := deps.AuditRepo.(*MockAuditRepository)
 	auditRepo.AssertCalled(t, "LogEvent", mock.Anything, "oauth_code_rejected", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
@@ -466,15 +404,19 @@ func TestTokenExchangeHandler_NonceMismatch(t *testing.T) {
 
 	state := encodeOAuthState("correct-nonce", "/dashboard", "login")
 	input := &dto.OAuthTokenRequest{
-		Code:  "some-code",
-		State: state,
+		Body: struct {
+			Code  string `json:"code" maxLength:"256"`
+			State string `json:"state" maxLength:"1024"`
+		}{
+			Code:  "some-code",
+			State: state,
+		},
 	}
 
 	resp, err := handler(context.Background(), input)
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), string(dto.OAuthErrorInvalidCode))
 	mockCodeRepo.AssertCalled(t, "MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything)
 	auditRepo := deps.AuditRepo.(*MockAuditRepository)
 	auditRepo.AssertCalled(t, "LogEvent", mock.Anything, "oauth_code_rejected", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -512,15 +454,19 @@ func TestTokenExchangeHandler_EmailExists(t *testing.T) {
 
 	state := encodeOAuthState("test-nonce", "/dashboard", "login")
 	input := &dto.OAuthTokenRequest{
-		Code:  "some-code",
-		State: state,
+		Body: struct {
+			Code  string `json:"code" maxLength:"256"`
+			State string `json:"state" maxLength:"1024"`
+		}{
+			Code:  "some-code",
+			State: state,
+		},
 	}
 
 	resp, err := handler(context.Background(), input)
 
 	assert.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), string(dto.OAuthErrorEmailExists))
 	mockCodeRepo.AssertCalled(t, "MarkAuthorizationCodeAsUsed", mock.Anything, mock.Anything)
 	auditRepo := deps.AuditRepo.(*MockAuditRepository)
 	auditRepo.AssertCalled(t, "LogEvent", mock.Anything, "oauth_login_failed", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
@@ -537,8 +483,39 @@ func TestTokenExchangeHandler_MalformedState(t *testing.T) {
 	handler := handlers.TokenExchangeHandler(deps)
 
 	input := &dto.OAuthTokenRequest{
-		Code:  "some-code",
-		State: "not-valid-base64!!!",
+		Body: struct {
+			Code  string `json:"code" maxLength:"256"`
+			State string `json:"state" maxLength:"1024"`
+		}{
+			Code:  "some-code",
+			State: "not-valid-base64!!!",
+		},
+	}
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestTokenExchangeHandler_EmptyState(t *testing.T) {
+	deps := &handlers.OAuthHandlerDeps{
+		AuthCodeRepo: &MockOAuthAuthorizationCodeRepository{},
+		OAuthSvc:     &MockOAuthService{},
+		TokenSvc:     &MockTokenService{},
+		TokenRepo:    &MockRefreshTokenRepository{},
+		AuditRepo:    newMockAuditRepo(),
+	}
+	handler := handlers.TokenExchangeHandler(deps)
+
+	input := &dto.OAuthTokenRequest{
+		Body: struct {
+			Code  string `json:"code" maxLength:"256"`
+			State string `json:"state" maxLength:"1024"`
+		}{
+			Code:  "some-code",
+			State: "",
+		},
 	}
 
 	resp, err := handler(context.Background(), input)

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -90,7 +90,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, auditRepo
 	handlers.RegisterPasswordResetRoutes(api, passwordResetDeps)
 
 	// OAuth provider routes (unauthenticated)
-	handlers.RegisterOAuthProviderRoutes(api, oauthAuthCodeRepo, oauthSvc, tokenSvc, tokenRepo, auditRepository)
+	handlers.RegisterOAuthProviderRoutes(api, oauthAuthCodeRepo, oauthSvc, tokenSvc, tokenRepo, auditRepository, frontendURL)
 
 	// Set password (authenticated) — for OAuth-only users to add a password
 	huma.Register(api, huma.Operation{

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -45,6 +45,7 @@ func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, func(),
 
 	router := chi.NewRouter()
 	router.Use(chiMiddleware.RealIP)
+	router.Use(chiMiddleware.Recoverer)
 
 	// Extract IP and User-Agent into request context (available to handlers via context).
 	router.Use(middleware.RequestInfo)

--- a/pkg/oauth/google/provider.go
+++ b/pkg/oauth/google/provider.go
@@ -134,29 +134,6 @@ func (p *GoogleProvider) GetUserInfo(ctx context.Context, accessToken string) (*
 	}, nil
 }
 
-func init() {
-	// Auto-register the Google provider if environment variables are set
-	provider, err := New()
-	if err != nil {
-		return // Should not happen since New() doesn't return error
-	}
-
-	// Check if required env vars are present
-	missing := false
-	for _, envVar := range provider.RequiredEnvVars() {
-		if os.Getenv(envVar) == "" {
-			missing = true
-			break
-		}
-	}
-
-	if !missing {
-		if err := oauth.Register(provider); err != nil {
-			fmt.Printf("oauth/google: failed to register provider: %v\n", err)
-		}
-	}
-}
-
 // TokenResponseWithExpiry includes expiry time for caching.
 type TokenResponseWithExpiry struct {
 	oauth.TokenResponse

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -12,8 +12,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"sync"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Errors returned by the OAuth provider registry.
@@ -130,7 +132,7 @@ func Register(provider Provider) error {
 	// Store provider info for public API
 	globalRegistry.providerInfo[name] = ProviderInfo{
 		ID:           name,
-		Name:         strings.Title(name),
+		Name:         cases.Title(language.English).String(name),
 		IconURL:      fmt.Sprintf("/assets/icons/%s.svg", name),
 		CallbackPath: fmt.Sprintf("/api/auth/oauth/%s/callback", name),
 	}
@@ -184,9 +186,9 @@ func DecodeOAuthState(encoded string) (*OAuthState, error) {
 		return nil, errors.New("oauth: invalid state: empty state parameter")
 	}
 
-	data, err := base64.StdEncoding.DecodeString(encoded)
+	data, err := base64.URLEncoding.DecodeString(encoded)
 	if err != nil {
-		data, err = base64.URLEncoding.DecodeString(encoded)
+		data, err = base64.StdEncoding.DecodeString(encoded)
 		if err != nil {
 			return nil, fmt.Errorf("oauth: invalid state encoding: %w", err)
 		}

--- a/pkg/oauth/provider.go
+++ b/pkg/oauth/provider.go
@@ -177,11 +177,19 @@ func (s *OAuthState) Encode() string {
 	return base64.URLEncoding.EncodeToString(data)
 }
 
-// DecodeOAuthState decodes a base64url-encoded OAuthState string.
+// DecodeOAuthState decodes a base64-encoded OAuthState string.
+// Accepts both standard base64 and base64url encodings.
 func DecodeOAuthState(encoded string) (*OAuthState, error) {
-	data, err := base64.URLEncoding.DecodeString(encoded)
+	if encoded == "" {
+		return nil, errors.New("oauth: invalid state: empty state parameter")
+	}
+
+	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return nil, fmt.Errorf("oauth: invalid state encoding: %w", err)
+		data, err = base64.URLEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("oauth: invalid state encoding: %w", err)
+		}
 	}
 
 	var state OAuthState

--- a/pkg/oauth/provider_test.go
+++ b/pkg/oauth/provider_test.go
@@ -84,6 +84,12 @@ func TestDecodeOAuthState(t *testing.T) {
 	assert.Equal(t, state.Purpose, decoded.Purpose)
 }
 
+func TestDecodeOAuthState_EmptyState(t *testing.T) {
+	_, err := oauth.DecodeOAuthState("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty state")
+}
+
 func TestDecodeOAuthState_InvalidEncoding(t *testing.T) {
 	_, err := oauth.DecodeOAuthState("not-valid-base64!!!")
 	assert.Error(t, err)

--- a/web/src/routes/auth/callback/+page.svelte
+++ b/web/src/routes/auth/callback/+page.svelte
@@ -18,8 +18,6 @@
 		const code = params.get('code');
 		const state = params.get('state');
 
-		console.log('[OAuth callback] page loaded', { code: !!code, state: !!state, stateLen: state?.length, search: window.location.search });
-
 		if (!code || !state) {
 			error = 'Invalid callback parameters.';
 			isLoading = false;
@@ -31,56 +29,43 @@
 	async function exchangeToken(code: string, state: string) {
 		try {
 			const body = JSON.stringify({ code, state });
-			console.log('[OAuth callback] POST /api/auth/oauth/token', { codeLen: code.length, stateLen: state.length });
 			const res = await fetch('/api/auth/oauth/token', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body,
 			});
 
-			console.log('[OAuth callback] POST response', { status: res.status, ok: res.ok });
-
 			if (!res.ok) {
 				const data = await res.json();
-				console.log('[OAuth callback] POST error body', data);
 				let redirect = '/login';
 				try {
 					const decoded = base64UrlToStandard(state);
-					console.log('[OAuth callback] decoding state', { decoded: decoded.slice(0, 40) + '...' });
 					const parsed = JSON.parse(atob(decoded));
-					console.log('[OAuth callback] state parsed', parsed);
 					redirect = parsed.redirect || '/login';
 				} catch (e) {
-					console.log('[OAuth callback] state parse failed', e);
+					// State unreadable — fall back to /login.
 				}
 				const errCode = data.title || data.detail || 'unknown_error';
-				console.log('[OAuth callback] redirecting to error', `${redirect}?oauth_error=${errCode}&provider=google`);
 				goto(`${redirect}?oauth_error=${errCode}&provider=google`);
 				return;
 			}
 
 			const data = await res.json();
-			console.log('[OAuth callback] token exchange success', { hasAccessToken: !!data.access_token, user: data.user });
 
 			localStorage.setItem('access_token', data.access_token);
 			localStorage.setItem('refresh_token', data.refresh_token);
 			localStorage.setItem('email_verified', String(data.user.email_verified));
 
-			console.log('[OAuth callback] tokens stored, verifying...', { storedToken: localStorage.getItem('access_token')?.slice(0, 20) + '...' });
-
 			let redirect = '/dashboard';
 			try {
 				const decoded = base64UrlToStandard(state);
 				const parsed = JSON.parse(atob(decoded));
-				console.log('[OAuth callback] state parsed for redirect', parsed);
 				redirect = parsed.redirect || '/dashboard';
 			} catch (e) {
-				console.log('[OAuth callback] state parse failed on success path', e);
+				// State unreadable — fall back to /dashboard.
 			}
-			console.log('[OAuth callback] navigating to', redirect);
 			goto(redirect);
 		} catch (e) {
-			console.log('[OAuth callback] network error', e);
 			goto('/login?oauth_error=network_error');
 		}
 	}

--- a/web/src/routes/auth/callback/+page.svelte
+++ b/web/src/routes/auth/callback/+page.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { LoaderCircle } from '@lucide/svelte';
+	import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '$lib/components/ui/card';
+
+	let error = $state('');
+	let isLoading = $state(true);
+
+	function base64UrlToStandard(str: string): string {
+		str = str.replace(/-/g, '+').replace(/_/g, '/');
+		const padding = str.length % 4;
+		if (padding) str += '='.repeat(4 - padding);
+		return str;
+	}
+
+	if (typeof window !== 'undefined') {
+		const params = new URLSearchParams(window.location.search);
+		const code = params.get('code');
+		const state = params.get('state');
+
+		console.log('[OAuth callback] page loaded', { code: !!code, state: !!state, stateLen: state?.length, search: window.location.search });
+
+		if (!code || !state) {
+			error = 'Invalid callback parameters.';
+			isLoading = false;
+		} else {
+			exchangeToken(code, state);
+		}
+	}
+
+	async function exchangeToken(code: string, state: string) {
+		try {
+			const body = JSON.stringify({ code, state });
+			console.log('[OAuth callback] POST /api/auth/oauth/token', { codeLen: code.length, stateLen: state.length });
+			const res = await fetch('/api/auth/oauth/token', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body,
+			});
+
+			console.log('[OAuth callback] POST response', { status: res.status, ok: res.ok });
+
+			if (!res.ok) {
+				const data = await res.json();
+				console.log('[OAuth callback] POST error body', data);
+				let redirect = '/login';
+				try {
+					const decoded = base64UrlToStandard(state);
+					console.log('[OAuth callback] decoding state', { decoded: decoded.slice(0, 40) + '...' });
+					const parsed = JSON.parse(atob(decoded));
+					console.log('[OAuth callback] state parsed', parsed);
+					redirect = parsed.redirect || '/login';
+				} catch (e) {
+					console.log('[OAuth callback] state parse failed', e);
+				}
+				const errCode = data.error || 'unknown_error';
+				console.log('[OAuth callback] redirecting to error', `${redirect}?oauth_error=${errCode}&provider=google`);
+				goto(`${redirect}?oauth_error=${errCode}&provider=google`);
+				return;
+			}
+
+			const data = await res.json();
+			console.log('[OAuth callback] token exchange success', { hasAccessToken: !!data.access_token, user: data.user });
+
+			localStorage.setItem('access_token', data.access_token);
+			localStorage.setItem('refresh_token', data.refresh_token);
+			localStorage.setItem('email_verified', String(data.user.email_verified));
+
+			console.log('[OAuth callback] tokens stored, verifying...', { storedToken: localStorage.getItem('access_token')?.slice(0, 20) + '...' });
+
+			let redirect = '/dashboard';
+			try {
+				const decoded = base64UrlToStandard(state);
+				const parsed = JSON.parse(atob(decoded));
+				console.log('[OAuth callback] state parsed for redirect', parsed);
+				redirect = parsed.redirect || '/dashboard';
+			} catch (e) {
+				console.log('[OAuth callback] state parse failed on success path', e);
+			}
+			console.log('[OAuth callback] navigating to', redirect);
+			goto(redirect);
+		} catch (e) {
+			console.log('[OAuth callback] network error', e);
+			goto('/login?oauth_error=network_error');
+		}
+	}
+</script>
+
+<div class="flex min-h-screen flex-col items-center justify-center px-4">
+	<Card class="w-full max-w-sm">
+		<CardHeader>
+			<CardTitle class="text-center">
+				{#if error}
+					Callback Error
+				{:else}
+					Connecting
+				{/if}
+			</CardTitle>
+			<CardDescription class="text-center">
+				{#if error}
+					{error}
+				{:else}
+					Please wait while we sign you in
+				{/if}
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="flex justify-center pb-6">
+			{#if !error}
+				<LoaderCircle class="h-8 w-8 animate-spin text-muted-foreground" />
+			{/if}
+		</CardContent>
+	</Card>
+</div>

--- a/web/src/routes/auth/callback/+page.svelte
+++ b/web/src/routes/auth/callback/+page.svelte
@@ -53,7 +53,7 @@
 				} catch (e) {
 					console.log('[OAuth callback] state parse failed', e);
 				}
-				const errCode = data.error || 'unknown_error';
+				const errCode = data.title || data.detail || 'unknown_error';
 				console.log('[OAuth callback] redirecting to error', `${redirect}?oauth_error=${errCode}&provider=google`);
 				goto(`${redirect}?oauth_error=${errCode}&provider=google`);
 				return;

--- a/web/src/routes/auth/callback/+page.ts
+++ b/web/src/routes/auth/callback/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -69,6 +69,15 @@
 	function handleForgotPassword() {
 		goto('/forgot-password');
 	}
+
+	function handleOAuthLogin() {
+		const state = btoa(JSON.stringify({
+			nonce: crypto.randomUUID(),
+			redirect: '/',
+			purpose: 'login',
+		}));
+		window.location.href = `/api/auth/oauth/google?state=${encodeURIComponent(state)}`;
+	}
 </script>
 
 <div class="flex min-h-screen flex-col justify-center bg-background px-4">
@@ -164,7 +173,7 @@
 			</div>
 
 			<div class="grid grid-cols-1 gap-3">
-				<Button variant="outline" type="button" onclick={() => alert('Coming soon')}>
+				<Button variant="outline" type="button" onclick={handleOAuthLogin}>
 					<svg class="mr-2 h-4 w-4" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.84z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
 					Google
 				</Button>

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -44,6 +44,15 @@
 		return Object.keys(newErrors).length === 0;
 	}
 
+	function handleOAuthRegister() {
+		const state = btoa(JSON.stringify({
+			nonce: crypto.randomUUID(),
+			redirect: '/',
+			purpose: 'register',
+		}));
+		window.location.href = `/api/auth/oauth/google?state=${encodeURIComponent(state)}`;
+	}
+
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
 		generalError = '';
@@ -199,7 +208,7 @@
 				</div>
 
 				<div class="grid grid-cols-1 gap-3">
-					<Button variant="outline" type="button" onclick={() => alert('Coming soon')}>
+					<Button variant="outline" type="button" onclick={handleOAuthRegister}>
 						<svg class="mr-2 h-4 w-4" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.84z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
 						Google
 					</Button>


### PR DESCRIPTION
## Summary

Fixes the Google OAuth login/registration flow end-to-end, resolving several bugs that prevented token exchange from working.

## Changes

- **Empty-state guard in `DecodeOAuthState`** — base64 decoding an empty string returned zero bytes, then `json.Unmarshal` produced "unexpected end of JSON input". Added early returns in both `dto/oauth.go` and `pkg/oauth/provider.go`.
- **FrontendURL redirect fix** — `OAuthCallbackHandler` used relative redirects that landed on the Go server (port 8080) instead of the Vite dev server (port 5173). Added `FrontendURL` to handler deps and prefixed all callback redirects.
- **Body wrapper for huma v2** — `OAuthTokenRequest` used flat struct fields instead of the required `Body struct {...}` pattern, so huma never parsed the JSON request body. Fixed both request and response DTOs.
- **DB schema fix** — `oauth_accounts` had `connected_at` column but sqlc queries referenced `created_at`. Replaced `connected_at` with `created_at` in migration, queries, and regenerated code.
- **Explicit Google provider registration** — Removed `init()` from the Google provider (it ran before env vars loaded). Registered explicitly in `main.go` after `godotenv.Load()`.
- **Recovery middleware** — Added `chi.Recoverer` to prevent server crashes on panics, plus structured error logging at 500 return points.

Closes #83