### PR TITLE
fix(auth): update email_verified in localStorage on verification and logout

### DIFF
--- a/web/src/routes/(protected)/profile/+page.svelte
+++ b/web/src/routes/(protected)/profile/+page.svelte
@@ -16,6 +16,7 @@
 		}
 		localStorage.removeItem('access_token');
 		localStorage.removeItem('refresh_token');
+		localStorage.removeItem('email_verified');
 		localStorage.removeItem('remember_me');
 		goto('/login');
 	}

--- a/web/src/routes/auth/verify-email/+page.svelte
+++ b/web/src/routes/auth/verify-email/+page.svelte
@@ -61,6 +61,7 @@
 				return;
 			}
 			localStorage.setItem('access_token', data.access_token);
+			localStorage.setItem('email_verified', 'true');
 			localStorage.removeItem('refresh_token');
 			status = 'success';
 


### PR DESCRIPTION
## Problem

After email verification, the "Email not verified" banner persisted because `localStorage.email_verified` was never updated to `'true'` after successful verification.

## Fix

1. **`web/src/routes/auth/verify-email/+page.svelte`** — Set `localStorage.setItem('email_verified', 'true')` after successful verification so the banner reads the updated status.

2. **`web/src/routes/(protected)/profile/+page.svelte`** — Clean up `email_verified` from localStorage on logout for data hygiene.