### PR TITLE
OAuth frontend error UX, email collision, link/unlink UI (#84)

### DIFF
--- a/internal/features/auth/dto/oauth.go
+++ b/internal/features/auth/dto/oauth.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"errors"
+	"time"
 
 	"github.com/shuvo-paul/medminder/pkg/oauth"
 )
@@ -148,6 +149,9 @@ type ProvidersResponse struct {
 type OAuthLinkInitInput struct {
 	Authorization string `header:"Authorization"`
 	Provider      string `path:"provider" doc:"OAuth provider identifier (e.g., google)"`
+	Body          struct {
+		Redirect string `json:"redirect" doc:"Where to return after linking (e.g., /profile)"`
+	}
 }
 
 // OAuthLinkInitResponse represents the response for initiating an OAuth link flow.
@@ -202,6 +206,57 @@ type OAuthCallbackInput struct {
 type OAuthCallbackOutput struct {
 	Redirect string `header:"Location"` // Redirect URL after callback
 	Status   int    `status:"302"`      // HTTP redirect status code
+}
+
+// OAuthAccountsInput represents the input for listing linked OAuth accounts.
+// This endpoint is authenticated via Bearer token in Authorization header.
+type OAuthAccountsInput struct {
+	Authorization string `header:"Authorization"`
+}
+
+// OAuthLinkedAccount represents a single linked OAuth provider account.
+type OAuthLinkedAccount struct {
+	ID             string    `json:"id"`
+	Provider       string    `json:"provider"`
+	ProviderUserID string    `json:"provider_user_id"`
+	CreatedAt      time.Time `json:"created_at"`
+	ProviderName   string    `json:"provider_name"`
+}
+
+// OAuthAccountsResponse represents the response for listing linked OAuth accounts.
+type OAuthAccountsResponse struct {
+	Body struct {
+		Accounts    []OAuthLinkedAccount `json:"accounts"`
+		HasPassword bool                 `json:"has_password"`
+	}
+}
+
+// OAuthUnlinkInput represents the input for unlinking an OAuth provider.
+type OAuthUnlinkInput struct {
+	Authorization string `header:"Authorization"`
+	Provider      string `path:"provider" doc:"OAuth provider identifier (e.g., google)"`
+}
+
+// OAuthUnlinkOutput represents the output for unlinking an OAuth provider.
+type OAuthUnlinkOutput struct {
+	Body struct {
+		Message string `json:"message" doc:"Success message"`
+	}
+}
+
+// OAuthLinkStatusInput represents the input for checking OAuth link status.
+type OAuthLinkStatusInput struct {
+	Authorization string `header:"Authorization"`
+	Provider      string `path:"provider" doc:"OAuth provider identifier (e.g., google)"`
+}
+
+// OAuthLinkStatusResponse represents the response for checking OAuth link status.
+type OAuthLinkStatusResponse struct {
+	Body struct {
+		Linked      bool `json:"linked"`
+		CanUnlink   bool `json:"can_unlink"`
+		HasPassword bool `json:"has_password"`
+	}
 }
 
 // ParseOAuthState parses the OAuth state from a string.

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -132,6 +132,11 @@ func (m *MockOAuthService) CanUnlinkProvider(ctx context.Context, userID uuid.UU
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockOAuthService) HasPassword(ctx context.Context, userID uuid.UUID) (bool, error) {
+	args := m.Called(ctx, userID)
+	return args.Bool(0), args.Error(1)
+}
+
 type MockRefreshTokenRepository struct {
 	mock.Mock
 }
@@ -167,6 +172,11 @@ func (m *MockOAuthAuthorizationCodeRepository) CreateAuthorizationCode(ctx conte
 
 func (m *MockOAuthAuthorizationCodeRepository) CreateAuthorizationCodeWithUserInfo(ctx context.Context, id uuid.UUID, codeHash string, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error) {
 	args := m.Called(ctx, id, codeHash, nonce, purpose, expiresAt, provider, providerUserID, providerEmail, providerName, providerEmailVerified)
+	return args.Get(0).(db.OauthAuthorizationCode), args.Error(1)
+}
+
+func (m *MockOAuthAuthorizationCodeRepository) CreateAuthorizationCodeWithUserInfoForLink(ctx context.Context, id uuid.UUID, codeHash string, userID uuid.UUID, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error) {
+	args := m.Called(ctx, id, codeHash, userID, nonce, purpose, expiresAt, provider, providerUserID, providerEmail, providerName, providerEmailVerified)
 	return args.Get(0).(db.OauthAuthorizationCode), args.Error(1)
 }
 

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -182,6 +182,42 @@ func RegisterOAuthProviderRoutes(api huma.API, authCodeRepo repository.OAuthAuth
 			{"bearer": {}},
 		},
 	}, OAuthLinkInitHandler(deps))
+
+	// List linked OAuth accounts - authenticated
+	huma.Register(api, huma.Operation{
+		OperationID: "list-oauth-accounts",
+		Method:      http.MethodGet,
+		Path:        "/api/auth/oauth/accounts",
+		Summary:     "List linked OAuth accounts",
+		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
+	}, OAuthAccountsHandler(deps))
+
+	// Unlink OAuth account - authenticated
+	huma.Register(api, huma.Operation{
+		OperationID: "unlink-oauth-account",
+		Method:      http.MethodDelete,
+		Path:        "/api/auth/oauth/accounts/{provider}",
+		Summary:     "Unlink an OAuth provider",
+		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
+	}, OAuthUnlinkHandler(deps))
+
+	// OAuth link status - authenticated
+	huma.Register(api, huma.Operation{
+		OperationID: "oauth-link-status",
+		Method:      http.MethodGet,
+		Path:        "/api/auth/oauth/accounts/{provider}/status",
+		Summary:     "Check OAuth link status for a provider",
+		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
+	}, OAuthLinkStatusHandler(deps))
 }
 
 // isValidRedirect checks if the redirect URL is a relative path or a trusted domain.
@@ -259,21 +295,49 @@ func OAuthCallbackHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 
 		// Store in database (5-minute expiry, SHA-256 hashed)
 		expiresAt := time.Now().Add(oauthAuthCodeExpiry)
-		_, err = deps.AuthCodeRepo.CreateAuthorizationCodeWithUserInfo(
-			ctx,
-			uuid.New(),
-			codeHash,
-			state.Nonce,
-			state.Purpose,
-			expiresAt,
-			input.Provider,
-			userInfo.ProviderUserID,
-			userInfo.Email,
-			userInfo.Name,
-			userInfo.EmailVerified,
-		)
-		if err != nil {
-			return nil, huma.Error500InternalServerError("failed to store authorization code", err)
+
+		if state.Purpose == "link" {
+			// Link flow: find the original code (created by OAuthLinkInitHandler)
+			// to associate the provider account with the authenticated user.
+			originalCode, err := deps.AuthCodeRepo.GetAuthorizationCodeByNonceAndPurpose(ctx, state.Nonce, "link")
+			if err != nil || !originalCode.UserID.Valid {
+				return nil, huma.Error500InternalServerError("failed to find original authorization code for linking", err)
+			}
+
+			_, err = deps.AuthCodeRepo.CreateAuthorizationCodeWithUserInfoForLink(
+				ctx,
+				uuid.New(),
+				codeHash,
+				originalCode.UserID.UUID,
+				state.Nonce,
+				state.Purpose,
+				expiresAt,
+				input.Provider,
+				userInfo.ProviderUserID,
+				userInfo.Email,
+				userInfo.Name,
+				userInfo.EmailVerified,
+			)
+			if err != nil {
+				return nil, huma.Error500InternalServerError("failed to store authorization code for linking", err)
+			}
+		} else {
+			_, err = deps.AuthCodeRepo.CreateAuthorizationCodeWithUserInfo(
+				ctx,
+				uuid.New(),
+				codeHash,
+				state.Nonce,
+				state.Purpose,
+				expiresAt,
+				input.Provider,
+				userInfo.ProviderUserID,
+				userInfo.Email,
+				userInfo.Name,
+				userInfo.EmailVerified,
+			)
+			if err != nil {
+				return nil, huma.Error500InternalServerError("failed to store authorization code", err)
+			}
 		}
 
 		// Encode original state base64url to pass back to frontend
@@ -324,29 +388,61 @@ func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 				fmt.Errorf("state nonce mismatch"))
 		}
 
-		// Get or create user by OAuth
-		oauthUser, err := deps.OAuthSvc.GetOrCreateUserByOAuth(ctx, authCodeInfo.Provider, &oauth.UserInfo{
-			ProviderUserID: authCodeInfo.ProviderUserID,
-			Email:          authCodeInfo.ProviderEmail,
-			EmailVerified:  authCodeInfo.ProviderEmailVerified,
-			Name:           authCodeInfo.ProviderName,
-		})
-		if err != nil {
-			// Mark code as used even on error to prevent further attempts
-			_, _ = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
+		var oauthUser *service.OAuthUser
 
-			if errors.Is(err, service.ErrEmailExists) {
-				logOAuthLoginFailed(ctx, deps.AuditRepo, authCodeInfo.Provider, authCodeInfo.ProviderEmail)
-				return nil, huma.Error409Conflict(string(dto.OAuthErrorEmailExists),
-					fmt.Errorf("email already exists"))
+		if authCodeInfo.Purpose == "link" {
+			// Link flow: associate the provider account with the existing user.
+			if !authCodeInfo.UserID.Valid {
+				_, _ = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
+				return nil, huma.Error500InternalServerError("invalid authorization code", errors.New("missing user binding"))
 			}
-			log.Error("oauth_token_exchange_get_or_create_user_failed",
-				log.F("error", err.Error()),
-				log.F("provider", authCodeInfo.Provider),
-				log.F("provider_user_id", authCodeInfo.ProviderUserID),
-				log.F("provider_email", authCodeInfo.ProviderEmail),
-			)
-			return nil, huma.Error500InternalServerError("authentication failed", err)
+
+			if err := deps.OAuthSvc.LinkOAuthAccount(ctx, authCodeInfo.UserID.UUID, authCodeInfo.Provider, authCodeInfo.ProviderUserID); err != nil {
+				_, _ = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
+
+				if errors.Is(err, service.ErrAccountWillBeLocked) {
+					return nil, huma.Error403Forbidden(string(dto.OAuthErrorAccountLocked),
+						fmt.Errorf("account will be locked out"))
+				}
+				log.Error("oauth_token_exchange_link_account_failed",
+					log.F("error", err.Error()),
+					log.F("provider", authCodeInfo.Provider),
+					log.F("provider_user_id", authCodeInfo.ProviderUserID),
+				)
+				return nil, huma.Error500InternalServerError("failed to link account", err)
+			}
+
+			// Fetch the user to generate tokens
+			user, err := deps.OAuthSvc.GetUserByOAuth(ctx, authCodeInfo.Provider, authCodeInfo.ProviderUserID)
+			if err != nil {
+				return nil, huma.Error500InternalServerError("failed to get user", err)
+			}
+			oauthUser = user
+		} else {
+			// Login/register flow: get or create user by OAuth
+			oauthUser, err = deps.OAuthSvc.GetOrCreateUserByOAuth(ctx, authCodeInfo.Provider, &oauth.UserInfo{
+				ProviderUserID: authCodeInfo.ProviderUserID,
+				Email:          authCodeInfo.ProviderEmail,
+				EmailVerified:  authCodeInfo.ProviderEmailVerified,
+				Name:           authCodeInfo.ProviderName,
+			})
+			if err != nil {
+				// Mark code as used even on error to prevent further attempts
+				_, _ = deps.AuthCodeRepo.MarkAuthorizationCodeAsUsed(ctx, codeHash)
+
+				if errors.Is(err, service.ErrEmailExists) {
+					logOAuthLoginFailed(ctx, deps.AuditRepo, authCodeInfo.Provider, authCodeInfo.ProviderEmail)
+					return nil, huma.Error409Conflict(string(dto.OAuthErrorEmailExists),
+						fmt.Errorf(`{"email":"%s","provider":"%s"}`, authCodeInfo.ProviderEmail, authCodeInfo.Provider))
+				}
+				log.Error("oauth_token_exchange_get_or_create_user_failed",
+					log.F("error", err.Error()),
+					log.F("provider", authCodeInfo.Provider),
+					log.F("provider_user_id", authCodeInfo.ProviderUserID),
+					log.F("provider_email", authCodeInfo.ProviderEmail),
+				)
+				return nil, huma.Error500InternalServerError("authentication failed", err)
+			}
 		}
 
 		// Mark authorization code as used (one-time use)
@@ -495,10 +591,18 @@ func OAuthLinkInitHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 		}
 		nonce := hex.EncodeToString(nonceBytes)
 
-		// Create state with purpose="link" (no redirect needed for linking)
+		// Validate redirect if provided
+		redirect := input.Body.Redirect
+		if redirect != "" && !isValidRedirect(redirect) {
+			return nil, huma.Error400BadRequest("invalid redirect URL", errors.New("redirect must be a relative path"))
+		}
+		if redirect == "" {
+			redirect = "/profile"
+		}
+
 		state := dto.OAuthState{
 			Nonce:    nonce,
-			Redirect: "",
+			Redirect: redirect,
 			Purpose:  "link",
 		}
 		encodedState := state.Encode()
@@ -557,6 +661,129 @@ func SetPasswordHandler(authSvc service.AuthService, tokenSvc service.TokenServi
 			Body: struct {
 				Message string `json:"message" doc:"Success message"`
 			}{Message: "password set successfully"},
+		}, nil
+	}
+}
+
+// OAuthAccountsHandler returns a handler that lists all OAuth accounts linked to the user.
+// GET /api/auth/oauth/accounts (authenticated)
+func OAuthAccountsHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthAccountsInput) (*dto.OAuthAccountsResponse, error) {
+	return func(ctx context.Context, input *dto.OAuthAccountsInput) (*dto.OAuthAccountsResponse, error) {
+		userID, err := ExtractUserIDFromAuth(input.Authorization, deps.TokenSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		providers, err := deps.OAuthSvc.GetUserOAuthProviders(ctx, userID)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to get linked accounts", err)
+		}
+
+		hasPassword, err := deps.OAuthSvc.HasPassword(ctx, userID)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to get user info", err)
+		}
+
+		allProviders := oauth.GetProviders()
+		providerNames := make(map[string]string)
+		for _, p := range allProviders {
+			providerNames[p.ID] = p.Name
+		}
+
+		accounts := make([]dto.OAuthLinkedAccount, len(providers))
+		for i, p := range providers {
+			providerName := providerNames[p]
+			if providerName == "" {
+				providerName = p
+			}
+			accounts[i] = dto.OAuthLinkedAccount{
+				ID:           "",
+				Provider:     p,
+				ProviderName: providerName,
+			}
+		}
+
+		return &dto.OAuthAccountsResponse{
+			Body: struct {
+				Accounts    []dto.OAuthLinkedAccount `json:"accounts"`
+				HasPassword bool                     `json:"has_password"`
+			}{Accounts: accounts, HasPassword: hasPassword},
+		}, nil
+	}
+}
+
+// OAuthUnlinkHandler returns a handler that unlinks an OAuth provider from the user.
+// DELETE /api/auth/oauth/accounts/{provider} (authenticated)
+func OAuthUnlinkHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthUnlinkInput) (*dto.OAuthUnlinkOutput, error) {
+	return func(ctx context.Context, input *dto.OAuthUnlinkInput) (*dto.OAuthUnlinkOutput, error) {
+		userID, err := ExtractUserIDFromAuth(input.Authorization, deps.TokenSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := deps.OAuthSvc.UnlinkOAuthAccount(ctx, userID, input.Provider); err != nil {
+			if errors.Is(err, repository.ErrOAuthAccountNotFound) {
+				return nil, huma.Error404NotFound("account not linked", err)
+			}
+			if errors.Is(err, service.ErrAccountWillBeLocked) {
+				return nil, huma.Error403Forbidden("cannot unlink last login method", err)
+			}
+			return nil, huma.Error500InternalServerError("failed to unlink account", err)
+		}
+
+		return &dto.OAuthUnlinkOutput{
+			Body: struct {
+				Message string `json:"message" doc:"Success message"`
+			}{Message: "provider unlinked successfully"},
+		}, nil
+	}
+}
+
+// OAuthLinkStatusHandler returns a handler that checks the OAuth link status for a provider.
+// GET /api/auth/oauth/accounts/{provider}/status (authenticated)
+func OAuthLinkStatusHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAuthLinkStatusInput) (*dto.OAuthLinkStatusResponse, error) {
+	return func(ctx context.Context, input *dto.OAuthLinkStatusInput) (*dto.OAuthLinkStatusResponse, error) {
+		userID, err := ExtractUserIDFromAuth(input.Authorization, deps.TokenSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		providers, err := deps.OAuthSvc.GetUserOAuthProviders(ctx, userID)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to get linked accounts", err)
+		}
+
+		linked := false
+		for _, p := range providers {
+			if p == input.Provider {
+				linked = true
+				break
+			}
+		}
+
+		canUnlink := false
+		if linked {
+			canUnlink, err = deps.OAuthSvc.CanUnlinkProvider(ctx, userID, input.Provider)
+			if err != nil {
+				return nil, huma.Error500InternalServerError("failed to check unlink status", err)
+			}
+		}
+
+		hasPassword, err := deps.OAuthSvc.HasPassword(ctx, userID)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to get user info", err)
+		}
+
+		return &dto.OAuthLinkStatusResponse{
+			Body: struct {
+				Linked      bool `json:"linked"`
+				CanUnlink   bool `json:"can_unlink"`
+				HasPassword bool `json:"has_password"`
+			}{
+				Linked:      linked,
+				CanUnlink:   canUnlink,
+				HasPassword: hasPassword,
+			},
 		}, nil
 	}
 }

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -404,6 +404,10 @@ func TokenExchangeHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 					return nil, huma.Error403Forbidden(string(dto.OAuthErrorAccountLocked),
 						fmt.Errorf("account will be locked out"))
 				}
+				if errors.Is(err, service.ErrProviderAlreadyLinked) {
+					return nil, huma.Error409Conflict(string(dto.OAuthErrorLinkFailed),
+						fmt.Errorf("already linked to another account"))
+				}
 				log.Error("oauth_token_exchange_link_account_failed",
 					log.F("error", err.Error()),
 					log.F("provider", authCodeInfo.Provider),

--- a/internal/features/auth/repository/oauth_repository.go
+++ b/internal/features/auth/repository/oauth_repository.go
@@ -35,6 +35,7 @@ type AuthorizationCodeInfo struct {
 type OAuthAuthorizationCodeRepository interface {
 	CreateAuthorizationCode(ctx context.Context, id uuid.UUID, codeHash string, userID uuid.NullUUID, nonce string, purpose string, expiresAt time.Time) (db.OauthAuthorizationCode, error)
 	CreateAuthorizationCodeWithUserInfo(ctx context.Context, id uuid.UUID, codeHash string, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error)
+	CreateAuthorizationCodeWithUserInfoForLink(ctx context.Context, id uuid.UUID, codeHash string, userID uuid.UUID, nonce string, purpose string, expiresAt time.Time, provider string, providerUserID string, providerEmail string, providerName string, providerEmailVerified bool) (db.OauthAuthorizationCode, error)
 	GetAuthorizationCodeByHash(ctx context.Context, codeHash string) (db.OauthAuthorizationCode, error)
 	GetAuthorizationCodeByNonceAndPurpose(ctx context.Context, nonce, purpose string) (db.OauthAuthorizationCode, error)
 	GetAndLockAuthorizationCode(ctx context.Context, codeHash string) (*AuthorizationCodeInfo, error)
@@ -58,6 +59,7 @@ func (r *oauthAccountRepository) CreateOAuthAccount(ctx context.Context, id uuid
 		UserID:         userID,
 		Provider:       provider,
 		ProviderUserID: providerUserID,
+		CreatedAt:      sql.NullTime{Time: time.Now(), Valid: true},
 	})
 }
 
@@ -136,6 +138,39 @@ func (r *oauthAuthorizationCodeRepository) CreateAuthorizationCodeWithUserInfo(c
 	var code db.OauthAuthorizationCode
 	err := r.db.QueryRowContext(ctx, query,
 		id, codeHash, nonce, purpose, expiresAt,
+		provider, providerUserID, providerEmail, providerName, providerEmailVerified,
+	).Scan(
+		&code.ID, &code.CodeHash, &code.UserID, &code.Nonce, &code.Purpose,
+		&code.ExpiresAt, &code.UsedAt, &code.CreatedAt,
+	)
+	if err != nil {
+		return db.OauthAuthorizationCode{}, err
+	}
+	return code, nil
+}
+
+func (r *oauthAuthorizationCodeRepository) CreateAuthorizationCodeWithUserInfoForLink(
+	ctx context.Context,
+	id uuid.UUID,
+	codeHash string,
+	userID uuid.UUID,
+	nonce string,
+	purpose string,
+	expiresAt time.Time,
+	provider string,
+	providerUserID string,
+	providerEmail string,
+	providerName string,
+	providerEmailVerified bool,
+) (db.OauthAuthorizationCode, error) {
+	const query = `
+		INSERT INTO oauth_authorization_codes (id, code_hash, user_id, nonce, purpose, expires_at, created_at, provider, provider_user_id, provider_email, provider_name, provider_email_verified)
+		VALUES ($1, $2, $3, $4, $5, $6, NOW(), $7, $8, $9, $10, $11)
+		RETURNING id, code_hash, user_id, nonce, purpose, expires_at, used_at, created_at
+	`
+	var code db.OauthAuthorizationCode
+	err := r.db.QueryRowContext(ctx, query,
+		id, codeHash, userID, nonce, purpose, expiresAt,
 		provider, providerUserID, providerEmail, providerName, providerEmailVerified,
 	).Scan(
 		&code.ID, &code.CodeHash, &code.UserID, &code.Nonce, &code.Purpose,

--- a/internal/features/auth/service/oauth_service.go
+++ b/internal/features/auth/service/oauth_service.go
@@ -21,6 +21,7 @@ type OAuthService interface {
 	LinkOAuthAccount(ctx context.Context, userID uuid.UUID, provider, providerUserID string) error
 	UnlinkOAuthAccount(ctx context.Context, userID uuid.UUID, provider string) error
 	GetUserOAuthProviders(ctx context.Context, userID uuid.UUID) ([]string, error)
+	HasPassword(ctx context.Context, userID uuid.UUID) (bool, error)
 	CanUnlinkProvider(ctx context.Context, userID uuid.UUID, provider string) (bool, error)
 }
 
@@ -110,6 +111,14 @@ func (s *oauthService) GetUserByOAuth(ctx context.Context, provider, providerUse
 	}
 
 	return s.toOAuthUser(&user), nil
+}
+
+func (s *oauthService) HasPassword(ctx context.Context, userID uuid.UUID) (bool, error) {
+	user, err := s.userRepo.GetUserByID(ctx, userID.String())
+	if err != nil {
+		return false, err
+	}
+	return user.PasswordHash.Valid && user.PasswordHash.String != "", nil
 }
 
 func (s *oauthService) toOAuthUser(user *db.User) *OAuthUser {

--- a/internal/features/auth/service/oauth_service.go
+++ b/internal/features/auth/service/oauth_service.go
@@ -152,6 +152,15 @@ func (s *oauthService) logAudit(ctx context.Context, eventType string, userID uu
 // If the user already has this provider linked with a different account, it replaces the link.
 // Returns ErrAccountWillBeLocked if linking would leave the user with no login method.
 func (s *oauthService) LinkOAuthAccount(ctx context.Context, userID uuid.UUID, provider, providerUserID string) error {
+	// Check if any other user already has this provider_user_id linked
+	ownerAccount, err := s.oauthAccountRepo.GetOAuthAccountByProviderAndUserID(ctx, provider, providerUserID)
+	if err == nil && ownerAccount.UserID != userID {
+		return ErrProviderAlreadyLinked
+	}
+	if err != nil && !errors.Is(err, repository.ErrOAuthAccountNotFound) {
+		return err
+	}
+
 	// Check if user already has this provider linked
 	existingAccount, err := s.oauthAccountRepo.GetOAuthAccountByUserIDAndProvider(ctx, userID, provider)
 	accountExists := !errors.Is(err, repository.ErrOAuthAccountNotFound)

--- a/internal/features/auth/service/oauth_service.go
+++ b/internal/features/auth/service/oauth_service.go
@@ -238,18 +238,12 @@ func (s *oauthService) UnlinkOAuthAccount(ctx context.Context, userID uuid.UUID,
 		return err
 	}
 
-	// Dead-end prevention: if password_hash is NULL, reject
-	if !user.PasswordHash.Valid || user.PasswordHash.String == "" {
-		return ErrAccountWillBeLocked
-	}
-
-	// Check: if this is the user's ONLY login method (no other OAuth providers), reject
+	// Dead-end prevention: reject if unlinking the only login method
 	oauthAccounts, err := s.oauthAccountRepo.GetOAuthAccountsByUserID(ctx, userID)
 	if err != nil {
 		return err
 	}
 
-	// If only one provider and we're removing it, check if user has password
 	if len(oauthAccounts) == 1 && oauthAccounts[0].Provider == provider {
 		if !user.PasswordHash.Valid || user.PasswordHash.String == "" {
 			return ErrAccountWillBeLocked

--- a/internal/features/auth/service/oauth_service_test.go
+++ b/internal/features/auth/service/oauth_service_test.go
@@ -801,6 +801,8 @@ func TestUnlinkOAuthAccount_DeadEndPrevention_NoPassword(t *testing.T) {
 		Return(oauthAccount, nil)
 	userRepo.On("GetUserByID", mock.Anything, userID.String()).
 		Return(existingUser, nil)
+	oauthRepo.On("GetOAuthAccountsByUserID", mock.Anything, userID).
+		Return([]db.OauthAccount{oauthAccount}, nil)
 
 	err := oauthSvc.UnlinkOAuthAccount(context.Background(), userID, provider)
 
@@ -838,7 +840,8 @@ func TestUnlinkOAuthAccount_DeadEndPrevention_OnlyProviderNoPassword(t *testing.
 		Return(oauthAccount, nil)
 	userRepo.On("GetUserByID", mock.Anything, userID.String()).
 		Return(existingUser, nil)
-	// Note: GetOAuthAccountsByUserID is NOT called because password check fails first
+	oauthRepo.On("GetOAuthAccountsByUserID", mock.Anything, userID).
+		Return([]db.OauthAccount{oauthAccount}, nil)
 
 	err := oauthSvc.UnlinkOAuthAccount(context.Background(), userID, provider)
 
@@ -846,6 +849,53 @@ func TestUnlinkOAuthAccount_DeadEndPrevention_OnlyProviderNoPassword(t *testing.
 	assert.True(t, errors.Is(err, service.ErrAccountWillBeLocked))
 	oauthRepo.AssertExpectations(t)
 	userRepo.AssertExpectations(t)
+}
+
+func TestUnlinkOAuthAccount_MultiProviderNoPassword(t *testing.T) {
+	userRepo := new(MockOAuthUserRepository)
+	oauthRepo := new(MockOAuthAccountRepository)
+	auditRepo := newMockAuditRepo()
+	oauthSvc := service.NewOAuthService(userRepo, oauthRepo, auditRepo)
+
+	userID := uuid.New()
+	provider := "google"
+
+	existingUser := db.User{
+		ID:            userID,
+		Email:         "user@example.com",
+		DisplayName:   "Test User",
+		PasswordHash:  sql.NullString{String: "", Valid: false},
+		EmailVerified: sql.NullBool{Bool: true, Valid: true},
+	}
+
+	googleAccount := db.OauthAccount{
+		ID:             uuid.New(),
+		UserID:         userID,
+		Provider:       "google",
+		ProviderUserID: "google-123",
+	}
+	githubAccount := db.OauthAccount{
+		ID:             uuid.New(),
+		UserID:         userID,
+		Provider:       "github",
+		ProviderUserID: "github-456",
+	}
+
+	oauthRepo.On("GetOAuthAccountByUserIDAndProvider", mock.Anything, userID, provider).
+		Return(googleAccount, nil)
+	userRepo.On("GetUserByID", mock.Anything, userID.String()).
+		Return(existingUser, nil)
+	oauthRepo.On("GetOAuthAccountsByUserID", mock.Anything, userID).
+		Return([]db.OauthAccount{googleAccount, githubAccount}, nil)
+	oauthRepo.On("DeleteOAuthAccountByUserIDAndProvider", mock.Anything, userID, provider).
+		Return(nil)
+
+	err := oauthSvc.UnlinkOAuthAccount(context.Background(), userID, provider)
+
+	assert.NoError(t, err)
+	oauthRepo.AssertExpectations(t)
+	userRepo.AssertExpectations(t)
+	auditRepo.AssertCalled(t, "LogEvent", mock.Anything, "oauth_unlinked", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestGetUserOAuthProviders_Success(t *testing.T) {

--- a/internal/features/auth/service/oauth_service_test.go
+++ b/internal/features/auth/service/oauth_service_test.go
@@ -546,6 +546,8 @@ func TestLinkOAuthAccount_Success(t *testing.T) {
 		EmailVerified: sql.NullBool{Bool: true, Valid: true},
 	}
 
+	oauthRepo.On("GetOAuthAccountByProviderAndUserID", mock.Anything, provider, providerUserID).
+		Return(db.OauthAccount{}, repository.ErrOAuthAccountNotFound)
 	oauthRepo.On("GetOAuthAccountByUserIDAndProvider", mock.Anything, userID, provider).
 		Return(db.OauthAccount{}, repository.ErrOAuthAccountNotFound)
 	userRepo.On("GetUserByID", mock.Anything, userID.String()).
@@ -589,6 +591,8 @@ func TestLinkOAuthAccount_UpsertReplacesOldLink(t *testing.T) {
 		ProviderUserID: oldProviderUserID,
 	}
 
+	oauthRepo.On("GetOAuthAccountByProviderAndUserID", mock.Anything, provider, newProviderUserID).
+		Return(db.OauthAccount{}, repository.ErrOAuthAccountNotFound)
 	oauthRepo.On("GetOAuthAccountByUserIDAndProvider", mock.Anything, userID, provider).
 		Return(existingOAuthAccount, nil)
 	userRepo.On("GetUserByID", mock.Anything, userID.String()).
@@ -632,6 +636,8 @@ func TestLinkOAuthAccount_DeadEndPrevention_NoPasswordSingleProvider(t *testing.
 		ProviderUserID: providerUserID,
 	}
 
+	oauthRepo.On("GetOAuthAccountByProviderAndUserID", mock.Anything, provider, providerUserID).
+		Return(existingOAuthAccount, nil)
 	oauthRepo.On("GetOAuthAccountByUserIDAndProvider", mock.Anything, userID, provider).
 		Return(existingOAuthAccount, nil)
 	userRepo.On("GetUserByID", mock.Anything, userID.String()).
@@ -664,6 +670,8 @@ func TestLinkOAuthAccount_DeadEndPrevention_NewLinkWouldLeaveNoPassword(t *testi
 		EmailVerified: sql.NullBool{Bool: true, Valid: true},
 	}
 
+	oauthRepo.On("GetOAuthAccountByProviderAndUserID", mock.Anything, provider, providerUserID).
+		Return(db.OauthAccount{}, repository.ErrOAuthAccountNotFound)
 	oauthRepo.On("GetOAuthAccountByUserIDAndProvider", mock.Anything, userID, provider).
 		Return(db.OauthAccount{}, repository.ErrOAuthAccountNotFound)
 	userRepo.On("GetUserByID", mock.Anything, userID.String()).
@@ -675,6 +683,34 @@ func TestLinkOAuthAccount_DeadEndPrevention_NewLinkWouldLeaveNoPassword(t *testi
 
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, service.ErrAccountWillBeLocked))
+}
+
+func TestLinkOAuthAccount_ProviderAlreadyLinkedToOtherUser(t *testing.T) {
+	userRepo := new(MockOAuthUserRepository)
+	oauthRepo := new(MockOAuthAccountRepository)
+	oauthSvc := service.NewOAuthService(userRepo, oauthRepo, newMockAuditRepo())
+
+	userID := uuid.New()
+	differentUserID := uuid.New()
+	provider := "google"
+	providerUserID := "google-123"
+
+	ownedAccount := db.OauthAccount{
+		ID:             uuid.New(),
+		UserID:         differentUserID,
+		Provider:       provider,
+		ProviderUserID: providerUserID,
+	}
+
+	oauthRepo.On("GetOAuthAccountByProviderAndUserID", mock.Anything, provider, providerUserID).
+		Return(ownedAccount, nil)
+
+	err := oauthSvc.LinkOAuthAccount(context.Background(), userID, provider, providerUserID)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, service.ErrProviderAlreadyLinked))
+	oauthRepo.AssertExpectations(t)
+	userRepo.AssertExpectations(t)
 }
 
 func TestUnlinkOAuthAccount_Success(t *testing.T) {

--- a/web/package.json
+++ b/web/package.json
@@ -13,15 +13,17 @@
 	},
 	"devDependencies": {
 		"@fontsource-variable/inter": "^5.2.8",
-		"@lucide/svelte": "^0.577.0",
+		"@lucide/svelte": "^1.17.0",
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.55.0",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.1.18",
 		"clsx": "^2.1.1",
+		"mode-watcher": "^1.1.0",
 		"svelte": "^5.51.0",
 		"svelte-check": "^4.4.2",
+		"svelte-sonner": "^1.1.1",
 		"tailwind-merge": "^3.5.0",
 		"tailwind-variants": "^3.2.2",
 		"tailwindcss": "^4.1.18",
@@ -35,5 +37,8 @@
 			"@tailwindcss/oxide",
 			"esbuild"
 		]
+	},
+	"dependencies": {
+		"bits-ui": "^2.18.1"
 	}
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -7,13 +7,17 @@ settings:
 importers:
 
   .:
+    dependencies:
+      bits-ui:
+        specifier: ^2.18.1
+        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)
     devDependencies:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
       '@lucide/svelte':
-        specifier: ^0.577.0
-        version: 0.577.0(svelte@5.55.4)
+        specifier: ^1.17.0
+        version: 1.17.0(svelte@5.55.4)
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
         version: 7.0.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))
@@ -32,12 +36,18 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      mode-watcher:
+        specifier: ^1.1.0
+        version: 1.1.0(svelte@5.55.4)
       svelte:
         specifier: ^5.51.0
         version: 5.55.4
       svelte-check:
         specifier: ^4.4.2
         version: 4.4.6(picomatch@4.0.4)(svelte@5.55.4)(typescript@5.9.3)
+      svelte-sonner:
+        specifier: ^1.1.1
+        version: 1.1.1(svelte@5.55.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -719,8 +729,20 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+
+  '@internationalized/date@3.12.2':
+    resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -745,8 +767,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lucide/svelte@0.577.0':
-    resolution: {integrity: sha512-0P6mkySd2MapIEgq08tADPmcN4DHndC/02PWwaLkOerXlx5Sv9aT4BxyXLIY+eccr0g/nEyCYiJesqS61YdBZQ==}
+  '@lucide/svelte@1.17.0':
+    resolution: {integrity: sha512-q06YCFBN5CO8cd1ADmLCxWRVMVb7xxvHzqC0lvNoxGa+FLW6Cd1Y1AOxgbQk4Iwe68vkAMCRveNHint4WoaVKg==}
     peerDependencies:
       svelte: ^5
 
@@ -992,6 +1014,9 @@ packages:
       svelte: ^5.0.0
       vite: ^6.3.0 || ^7.0.0
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
 
@@ -1167,6 +1192,13 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bits-ui@2.18.1:
+    resolution: {integrity: sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@internationalized/date': ^3.8.1
+      svelte: ^5.33.0
+
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
@@ -1262,6 +1294,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1453,6 +1489,9 @@ packages:
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1707,6 +1746,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
@@ -1728,6 +1771,11 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mode-watcher@1.1.0:
+    resolution: {integrity: sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g==}
+    peerDependencies:
+      svelte: ^5.27.0
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1864,6 +1912,30 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  runed@0.23.4:
+    resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  runed@0.25.0:
+    resolution: {integrity: sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  runed@0.28.0:
+    resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
+    peerDependencies:
+      svelte: ^5.7.0
+
+  runed@0.35.1:
+    resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.21.0
+      svelte: ^5.7.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -1989,6 +2061,9 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -2001,9 +2076,29 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
+  svelte-sonner@1.1.1:
+    resolution: {integrity: sha512-5cd3p7wa4cq0NsqslMwdlPb7x1JglEZ/GKrLePWNr5bCxR1nagAVrY01FRFrXfUGs41miLt3C327+8XJo5BzZw==}
+    peerDependencies:
+      svelte: ^5.0.0
+
+  svelte-toolbelt@0.10.6:
+    resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.30.2
+
+  svelte-toolbelt@0.7.1:
+    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0
+
   svelte@5.55.4:
     resolution: {integrity: sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==}
     engines: {node: '>=18'}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -2048,6 +2143,9 @@ packages:
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -2997,7 +3095,22 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@fontsource-variable/inter@5.2.8': {}
+
+  '@internationalized/date@3.12.2':
+    dependencies:
+      '@swc/helpers': 0.5.23
 
   '@isaacs/cliui@9.0.0': {}
 
@@ -3025,7 +3138,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/svelte@0.577.0(svelte@5.55.4)':
+  '@lucide/svelte@1.17.0(svelte@5.55.4)':
     dependencies:
       svelte: 5.55.4
 
@@ -3212,6 +3325,10 @@ snapshots:
       vite: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
       vitefu: 1.1.3(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
   '@tailwindcss/node@4.2.4':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -3358,6 +3475,19 @@ snapshots:
 
   baseline-browser-mapping@2.10.20: {}
 
+  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4):
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/dom': 1.7.6
+      '@internationalized/date': 3.12.2
+      esm-env: 1.2.2
+      runed: 0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)
+      svelte: 5.55.4
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)
+      tabbable: 6.4.0
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
+
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
@@ -3456,6 +3586,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -3715,6 +3847,8 @@ snapshots:
 
   idb@7.1.1: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -3932,6 +4066,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
@@ -3951,6 +4087,12 @@ snapshots:
       brace-expansion: 2.1.0
 
   minipass@7.1.3: {}
+
+  mode-watcher@1.1.0(svelte@5.55.4):
+    dependencies:
+      runed: 0.25.0(svelte@5.55.4)
+      svelte: 5.55.4
+      svelte-toolbelt: 0.7.1(svelte@5.55.4)
 
   mri@1.2.0: {}
 
@@ -4104,6 +4246,30 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.2
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
+
+  runed@0.23.4(svelte@5.55.4):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.4
+
+  runed@0.25.0(svelte@5.55.4):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.4
+
+  runed@0.28.0(svelte@5.55.4):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.4
+
+  runed@0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4):
+    dependencies:
+      dequal: 2.0.3
+      esm-env: 1.2.2
+      lz-string: 1.5.0
+      svelte: 5.55.4
+    optionalDependencies:
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
 
   sade@1.8.1:
     dependencies:
@@ -4271,6 +4437,10 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.4)(typescript@5.9.3):
@@ -4284,6 +4454,27 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-sonner@1.1.1(svelte@5.55.4):
+    dependencies:
+      runed: 0.28.0(svelte@5.55.4)
+      svelte: 5.55.4
+
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.4)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)))(svelte@5.55.4)
+      style-to-object: 1.0.14
+      svelte: 5.55.4
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
+
+  svelte-toolbelt@0.7.1(svelte@5.55.4):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.23.4(svelte@5.55.4)
+      style-to-object: 1.0.14
+      svelte: 5.55.4
 
   svelte@5.55.4:
     dependencies:
@@ -4305,6 +4496,8 @@ snapshots:
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - '@typescript-eslint/types'
+
+  tabbable@6.4.0: {}
 
   tailwind-merge@3.5.0: {}
 
@@ -4344,6 +4537,8 @@ snapshots:
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
+
+  tslib@2.8.1: {}
 
   tw-animate-css@1.4.0: {}
 

--- a/web/src/lib/components/ui/alert/alert-action.svelte
+++ b/web/src/lib/components/ui/alert/alert-action.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-action"
+	class={cn("absolute top-2.5 right-3", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/alert-description.svelte
+++ b/web/src/lib/components/ui/alert/alert-description.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-description"
+	class={cn(
+		"text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/alert-title.svelte
+++ b/web/src/lib/components/ui/alert/alert-title.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-title"
+	class={cn(
+		"font-medium group-has-[>svg]/alert:col-start-2 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/alert.svelte
+++ b/web/src/lib/components/ui/alert/alert.svelte
@@ -1,0 +1,43 @@
+<script lang="ts" module>
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const alertVariants = tv({
+		base: "grid gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 group/alert relative w-full",
+		variants: {
+			variant: {
+				default: "bg-card text-card-foreground",
+				destructive: "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type AlertVariant = VariantProps<typeof alertVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "default",
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		variant?: AlertVariant;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert"
+	role="alert"
+	class={cn(alertVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/index.ts
+++ b/web/src/lib/components/ui/alert/index.ts
@@ -1,0 +1,17 @@
+import Root from "./alert.svelte";
+import Description from "./alert-description.svelte";
+import Title from "./alert-title.svelte";
+import Action from "./alert-action.svelte";
+export { alertVariants, type AlertVariant } from "./alert.svelte";
+
+export {
+	Root,
+	Description,
+	Title,
+	Action,
+	//
+	Root as Alert,
+	Description as AlertDescription,
+	Title as AlertTitle,
+	Action as AlertAction,
+};

--- a/web/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/web/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/web/src/lib/components/ui/dialog/dialog-description.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/web/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end gap-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/web/src/lib/components/ui/dialog/dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("flex flex-col gap-y-1.5 text-center sm:text-left", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/web/src/lib/components/ui/dialog/dialog-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	class={cn("text-lg font-semibold leading-none tracking-tight", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/dialog/dialog.svelte
+++ b/web/src/lib/components/ui/dialog/dialog.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+
+	let {
+		class: className,
+		open,
+		onclose,
+		children,
+	}: {
+		open: boolean;
+		onclose?: () => void;
+		class?: string;
+		children?: import("svelte").Snippet;
+	} = $props();
+
+	let ref = $state<HTMLDivElement | null>(null);
+
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) onclose?.();
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose?.();
+	}
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+		data-state={open ? 'open' : 'closed'}
+		onclick={handleBackdropClick}
+		onkeydown={handleKeydown}
+		role="presentation"
+	>
+		<div
+			bind:this={ref}
+			role="dialog"
+			aria-modal="true"
+			data-state={open ? 'open' : 'closed'}
+			class={cn(
+				"fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg sm:max-w-lg",
+				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200",
+			className
+		)}>
+		{@render children?.()}
+		</div>
+	</div>
+{/if}

--- a/web/src/lib/components/ui/dialog/index.ts
+++ b/web/src/lib/components/ui/dialog/index.ts
@@ -1,0 +1,22 @@
+import Root from "./dialog.svelte";
+import Content from "./dialog-content.svelte";
+import Description from "./dialog-description.svelte";
+import Footer from "./dialog-footer.svelte";
+import Header from "./dialog-header.svelte";
+import Title from "./dialog-title.svelte";
+
+export {
+	Root,
+	Content,
+	Description,
+	Footer,
+	Header,
+	Title,
+	//
+	Root as Dialog,
+	Content as DialogContent,
+	Description as DialogDescription,
+	Footer as DialogFooter,
+	Header as DialogHeader,
+	Title as DialogTitle,
+};

--- a/web/src/lib/components/ui/sonner/index.ts
+++ b/web/src/lib/components/ui/sonner/index.ts
@@ -1,0 +1,1 @@
+export { default as Toaster } from "./sonner.svelte";

--- a/web/src/lib/components/ui/sonner/sonner.svelte
+++ b/web/src/lib/components/ui/sonner/sonner.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { Toaster as Sonner, type ToasterProps as SonnerProps } from "svelte-sonner";
+	import { mode } from "mode-watcher";
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
+	import OctagonXIcon from '@lucide/svelte/icons/octagon-x';
+	import InfoIcon from '@lucide/svelte/icons/info';
+	import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
+
+	let { ...restProps }: SonnerProps = $props();
+</script>
+
+<Sonner
+	theme={mode.current}
+	class="toaster group"
+	style="--normal-bg: var(--color-popover); --normal-text: var(--color-popover-foreground); --normal-border: var(--color-border);"
+	{...restProps}
+>
+	{#snippet loadingIcon()}
+		<Loader2Icon class="size-4 animate-spin" />
+	{/snippet}
+	{#snippet successIcon()}
+		<CircleCheckIcon class="size-4" />
+	{/snippet}
+	{#snippet errorIcon()}
+		<OctagonXIcon class="size-4" />
+	{/snippet}
+	{#snippet infoIcon()}
+		<InfoIcon class="size-4" />
+	{/snippet}
+	{#snippet warningIcon()}
+		<TriangleAlertIcon class="size-4" />
+	{/snippet}
+</Sonner>

--- a/web/src/routes/(protected)/profile/+page.svelte
+++ b/web/src/routes/(protected)/profile/+page.svelte
@@ -1,17 +1,157 @@
 <script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
 	import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Dialog } from '$lib/components/ui/dialog';
 	import UserRound from '@lucide/svelte/icons/user-round';
-	import { goto } from '$app/navigation';
+	import Globe from '@lucide/svelte/icons/globe';
+	import Unlink from '@lucide/svelte/icons/unlink';
+	import Link from '@lucide/svelte/icons/link';
+	import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
+	import Eye from '@lucide/svelte/icons/eye';
+	import EyeOff from '@lucide/svelte/icons/eye-off';
 
-	async function handleLogout() {
-		const token = localStorage.getItem('access_token');
-		if (token) {
-			await fetch('/api/auth/logout', {
+	const urlParams = $derived($page.url.searchParams);
+	const linkedProvider = $derived(urlParams.get('linked'));
+	const oauthError = $derived(urlParams.get('oauth_error'));
+
+	let accounts = $state<string[]>([]);
+	let hasPassword = $state(false);
+	let isLoading = $state(true);
+	let unlinkProvider = $state<string | null>(null);
+	let isUnlinking = $state(false);
+	let unlinkError = $state('');
+
+	let showSetPassword = $state(false);
+	let newPassword = $state('');
+	let confirmPassword = $state('');
+	let showPassword = $state(false);
+	let isSettingPassword = $state(false);
+	let passwordError = $state('');
+
+	function getToken() {
+		return localStorage.getItem('access_token') || '';
+	}
+
+	async function fetchAccounts() {
+		isLoading = true;
+		try {
+			const res = await fetch('/api/auth/oauth/accounts', {
+				headers: { Authorization: `Bearer ${getToken()}` },
+			});
+			if (res.ok) {
+				const data = await res.json();
+				accounts = data.accounts?.map((a: { provider: string }) => a.provider) || [];
+				hasPassword = data.has_password || false;
+			}
+		} catch (e) {
+			console.error('Failed to fetch accounts', e);
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	async function handleLinkOAuth(provider: string) {
+		try {
+			const res = await fetch(`/api/auth/oauth/${provider}/init`, {
 				method: 'POST',
 				headers: {
-					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${getToken()}`,
 				},
+				body: JSON.stringify({ redirect: '/profile' }),
+			});
+			if (!res.ok) {
+				toast.error('Failed to initiate link');
+				return;
+			}
+			const data = await res.json();
+			const state = data.state;
+			window.location.href = `/api/auth/oauth/${provider}?state=${encodeURIComponent(state)}`;
+		} catch {
+			toast.error('Network error');
+		}
+	}
+
+	async function handleUnlink() {
+		if (!unlinkProvider) return;
+		isUnlinking = true;
+		unlinkError = '';
+		try {
+			const res = await fetch(`/api/auth/oauth/accounts/${unlinkProvider}`, {
+				method: 'DELETE',
+				headers: { Authorization: `Bearer ${getToken()}` },
+			});
+			if (res.ok) {
+				toast.success(`${unlinkProvider.charAt(0).toUpperCase() + unlinkProvider.slice(1)} account unlinked`);
+				unlinkProvider = null;
+				await fetchAccounts();
+			} else if (res.status === 403) {
+				unlinkError = 'Cannot unlink your last login method. Set a password first.';
+			} else {
+				const data = await res.json();
+				unlinkError = data.detail || 'Failed to unlink';
+			}
+		} catch {
+			unlinkError = 'Network error';
+		} finally {
+			isUnlinking = false;
+		}
+	}
+
+	async function handleSetPassword() {
+		passwordError = '';
+		if (newPassword.length < 8) {
+			passwordError = 'Password must be at least 8 characters';
+			return;
+		}
+		if (!/[A-Z]/.test(newPassword) || !/[a-z]/.test(newPassword) || !/[0-9]/.test(newPassword)) {
+			passwordError = 'Password must contain uppercase, lowercase, and number';
+			return;
+		}
+		if (newPassword !== confirmPassword) {
+			passwordError = 'Passwords do not match';
+			return;
+		}
+
+		isSettingPassword = true;
+		try {
+			const res = await fetch('/api/auth/password/set', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${getToken()}`,
+				},
+				body: JSON.stringify({ password: newPassword }),
+			});
+			if (res.ok) {
+				toast.success('Password set successfully');
+				hasPassword = true;
+				showSetPassword = false;
+				newPassword = '';
+				confirmPassword = '';
+			} else {
+				const data = await res.json();
+				passwordError = data.detail || 'Failed to set password';
+			}
+		} catch {
+			passwordError = 'Network error';
+		} finally {
+			isSettingPassword = false;
+		}
+	}
+
+	function handleLogout() {
+		const token = getToken();
+		if (token) {
+			fetch('/api/auth/logout', {
+				method: 'POST',
+				headers: { Authorization: `Bearer ${token}` },
 			});
 		}
 		localStorage.removeItem('access_token');
@@ -20,30 +160,217 @@
 		localStorage.removeItem('remember_me');
 		goto('/login');
 	}
+
+	// Fetch accounts on load
+	$effect(() => {
+		fetchAccounts();
+	});
+
+	// Show toast for successful link
+	$effect(() => {
+		if (linkedProvider) {
+			toast.success(`${linkedProvider.charAt(0).toUpperCase() + linkedProvider.slice(1)} account linked successfully`);
+			// Clean URL
+			const url = new URL(window.location.href);
+			url.searchParams.delete('linked');
+			window.history.replaceState({}, '', url.toString());
+		}
+	});
+
+	// Show error toast for OAuth errors
+	$effect(() => {
+		if (oauthError) {
+			const provider = urlParams.get('provider') || '';
+			if (oauthError === 'cancelled') {
+				toast.error('Linking cancelled');
+			} else if (oauthError === 'invalid_state') {
+				toast.error('Session expired. Please try again.');
+			} else if (oauthError === 'link_failed') {
+				toast.error('Failed to link account');
+			} else if (oauthError === 'account_locked') {
+				toast.error('Cannot link — set a password first to avoid losing access');
+			}
+			// Clean URL
+			const url = new URL(window.location.href);
+			url.searchParams.delete('oauth_error');
+			url.searchParams.delete('provider');
+			window.history.replaceState({}, '', url.toString());
+		}
+	});
+
+	const linkedAccounts = $derived(accounts);
+	const isGoogleLinked = $derived(linkedAccounts.includes('google'));
 </script>
 
 <div class="px-4 py-6">
 	<header class="mb-6">
-		<h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
-		<p class="text-sm text-muted-foreground">Account &amp; settings</p>
+		<h1 class="text-2xl font-semibold tracking-tight">Settings</h1>
+		<p class="text-sm text-muted-foreground">Account &amp; security</p>
 	</header>
 
-	<Card>
-		<CardContent class="flex flex-col items-center gap-4 py-12 text-center">
-			<div class="rounded-full bg-muted p-4">
-				<UserRound class="size-8 text-muted-foreground" />
+	<!-- OAuth Accounts -->
+	<Card class="mb-4">
+		<CardHeader>
+			<CardTitle class="text-base">Connected Accounts</CardTitle>
+			<CardDescription>Link your Google account for quick sign-in</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-3">
+			<div class="flex items-center justify-between rounded-lg border p-3">
+				<div class="flex items-center gap-3">
+					<Globe class="size-5 text-muted-foreground" />
+					<div>
+						<p class="text-sm font-medium">Google</p>
+						<p class="text-xs text-muted-foreground">
+							{isGoogleLinked ? 'Connected' : 'Not connected'}
+						</p>
+					</div>
+				</div>
+				<div class="flex gap-2">
+					{#if isGoogleLinked}
+						<Button
+							variant="outline"
+							size="sm"
+							onclick={() => (unlinkProvider = 'google')}
+						>
+							<Unlink class="mr-1 size-3" />
+							Unlink
+						</Button>
+					{:else}
+						<Button
+							variant="outline"
+							size="sm"
+							onclick={() => handleLinkOAuth('google')}
+							disabled={isLoading}
+						>
+							<Link class="mr-1 size-3" />
+							Link
+						</Button>
+					{/if}
+				</div>
 			</div>
-			<div>
-				<CardTitle class="text-base">Set up your profile</CardTitle>
-				<CardDescription class="mt-1">Personalize your MedMinder experience.</CardDescription>
-			</div>
-			<Button variant="outline">Edit Profile</Button>
+
+			{#if isLoading}
+				<p class="text-center text-xs text-muted-foreground">Loading...</p>
+			{/if}
 		</CardContent>
 	</Card>
 
-	<div class="mt-6">
-		<Button variant="ghost" class="w-full text-destructive" onclick={handleLogout}>
-			Sign Out
-		</Button>
-	</div>
+	<!-- Password Section -->
+	<Card class="mb-4">
+		<CardHeader>
+			<CardTitle class="text-base">Password</CardTitle>
+			<CardDescription>
+				{hasPassword ? 'Password is set' : 'Set a password for email sign-in'}
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			{#if hasPassword}
+				<p class="text-sm text-muted-foreground">Your account has a password. You can sign in with email and password.</p>
+			{:else if showSetPassword}
+				<form onsubmit={(e) => { e.preventDefault(); handleSetPassword(); }} class="space-y-3">
+					<div class="space-y-1">
+						<Label for="new-password">New Password</Label>
+						<div class="relative">
+							<Input
+								id="new-password"
+								type={showPassword ? 'text' : 'password'}
+								bind:value={newPassword}
+								class="pr-10"
+								placeholder="8+ chars, upper+lower+number"
+							/>
+							<button
+								type="button"
+								onclick={() => (showPassword = !showPassword)}
+								class="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+							>
+								{#if showPassword}
+									<EyeOff class="h-4 w-4" />
+								{:else}
+									<Eye class="h-4 w-4" />
+								{/if}
+							</button>
+						</div>
+					</div>
+					<div class="space-y-1">
+						<Label for="confirm-password">Confirm Password</Label>
+						<Input
+							id="confirm-password"
+							type="password"
+							bind:value={confirmPassword}
+							placeholder="Repeat your password"
+						/>
+					</div>
+					{#if passwordError}
+						<p class="text-sm text-destructive">{passwordError}</p>
+					{/if}
+					<div class="flex gap-2">
+						<Button type="submit" disabled={isSettingPassword}>
+							{isSettingPassword ? 'Setting...' : 'Set Password'}
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							onclick={() => { showSetPassword = false; passwordError = ''; }}
+						>
+							Cancel
+						</Button>
+					</div>
+				</form>
+			{:else}
+				<Button variant="outline" onclick={() => (showSetPassword = true)}>
+					Set Password
+				</Button>
+			{/if}
+		</CardContent>
+	</Card>
+
+	<!-- Sign Out -->
+	<Button variant="ghost" class="w-full text-destructive" onclick={handleLogout}>
+		Sign Out
+	</Button>
 </div>
+
+<!-- Unlink Confirmation Dialog -->
+<Dialog
+	open={unlinkProvider !== null}
+	onclose={() => { unlinkProvider = null; unlinkError = ''; }}
+>
+	<div class="space-y-4">
+		<div class="space-y-2">
+			<h2 class="text-lg font-semibold">Unlink {unlinkProvider} Account</h2>
+			<p class="text-sm text-muted-foreground">
+				Are you sure you want to unlink your {unlinkProvider} account?
+			</p>
+		</div>
+
+		{#if !hasPassword}
+			<Alert variant="destructive">
+				<TriangleAlert class="h-4 w-4" />
+				<AlertTitle>Warning</AlertTitle>
+				<AlertDescription>
+					You don't have a password set. If you unlink this account and it's your only login method, you may lose access.
+				</AlertDescription>
+			</Alert>
+		{/if}
+
+		{#if unlinkError}
+			<p class="text-sm text-destructive">{unlinkError}</p>
+		{/if}
+
+		<div class="flex justify-end gap-2">
+			<Button
+				variant="outline"
+				onclick={() => { unlinkProvider = null; unlinkError = ''; }}
+			>
+				Cancel
+			</Button>
+			<Button
+				variant="destructive"
+				onclick={handleUnlink}
+				disabled={isUnlinking}
+			>
+				{isUnlinking ? 'Unlinking...' : 'Unlink'}
+			</Button>
+		</div>
+	</div>
+</Dialog>

--- a/web/src/routes/(protected)/profile/+page.svelte
+++ b/web/src/routes/(protected)/profile/+page.svelte
@@ -186,7 +186,7 @@
 			} else if (oauthError === 'invalid_state') {
 				toast.error('Session expired. Please try again.');
 			} else if (oauthError === 'link_failed') {
-				toast.error('Failed to link account');
+				toast.error(urlParams.get('oauth_message') || 'Failed to link account');
 			} else if (oauthError === 'account_locked') {
 				toast.error('Cannot link — set a password first to avoid losing access');
 			}
@@ -194,6 +194,7 @@
 			const url = new URL(window.location.href);
 			url.searchParams.delete('oauth_error');
 			url.searchParams.delete('provider');
+			url.searchParams.delete('oauth_message');
 			window.history.replaceState({}, '', url.toString());
 		}
 	});

--- a/web/src/routes/(protected)/profile/+page.svelte
+++ b/web/src/routes/(protected)/profile/+page.svelte
@@ -344,12 +344,16 @@
 			</p>
 		</div>
 
-		{#if !hasPassword}
+		{#if !hasPassword && accounts.length <= 1}
+			<p class="text-sm text-destructive">
+				You don't have a password set. Add a password before unlinking your only login method.
+			</p>
+		{:else if !hasPassword}
 			<Alert variant="destructive">
 				<TriangleAlert class="h-4 w-4" />
 				<AlertTitle>Warning</AlertTitle>
 				<AlertDescription>
-					You don't have a password set. If you unlink this account and it's your only login method, you may lose access.
+					You don't have a password set. If you unlink this account, you'll have one login method remaining.
 				</AlertDescription>
 			</Alert>
 		{/if}
@@ -363,15 +367,17 @@
 				variant="outline"
 				onclick={() => { unlinkProvider = null; unlinkError = ''; }}
 			>
-				Cancel
+				{!hasPassword && accounts.length <= 1 ? 'Close' : 'Cancel'}
 			</Button>
-			<Button
-				variant="destructive"
-				onclick={handleUnlink}
-				disabled={isUnlinking}
-			>
-				{isUnlinking ? 'Unlinking...' : 'Unlink'}
-			</Button>
+			{#if !(!hasPassword && accounts.length <= 1)}
+				<Button
+					variant="destructive"
+					onclick={handleUnlink}
+					disabled={isUnlinking}
+				>
+					{isUnlinking ? 'Unlinking...' : 'Unlink'}
+				</Button>
+			{/if}
 		</div>
 	</div>
 </Dialog>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -3,11 +3,14 @@
 	import favicon from '$lib/assets/favicon.svg';
 	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 	import EmailVerificationBanner from '$lib/components/EmailVerificationBanner.svelte';
+	import { Toaster } from '$lib/components/ui/sonner';
 
 	let { children } = $props();
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
+
+<Toaster position="top-center" />
 
 <header class="fixed top-0 right-0 left-0 z-50 border-b border-border bg-background/95 backdrop-blur-sm">
 	<div class="mx-auto flex h-12 max-w-md items-center justify-end px-4">

--- a/web/src/routes/auth/callback/+page.svelte
+++ b/web/src/routes/auth/callback/+page.svelte
@@ -63,6 +63,11 @@
 
 				const params = new URLSearchParams({ oauth_error: errCode, provider: 'google' });
 				if (email) params.set('email', email);
+
+				if (errCode === 'link_failed') {
+					const errorMsg = data.errors?.[0]?.message;
+					if (errorMsg) params.set('oauth_message', errorMsg);
+				}
 				goto(`${redirect}?${params.toString()}`);
 				return;
 			}

--- a/web/src/routes/auth/callback/+page.svelte
+++ b/web/src/routes/auth/callback/+page.svelte
@@ -38,6 +38,7 @@
 			if (!res.ok) {
 				const data = await res.json();
 				let redirect = '/login';
+				let email = '';
 				try {
 					const decoded = base64UrlToStandard(state);
 					const parsed = JSON.parse(atob(decoded));
@@ -46,7 +47,20 @@
 					// State unreadable — fall back to /login.
 				}
 				const errCode = data.title || data.detail || 'unknown_error';
-				goto(`${redirect}?oauth_error=${errCode}&provider=google`);
+
+				// Try to extract email from error detail for email_exists
+				if (errCode === 'email_exists' && data.detail) {
+					try {
+						const detail = JSON.parse(data.detail);
+						email = detail.email || '';
+					} catch {
+						// detail is just a string, not JSON
+					}
+				}
+
+				const params = new URLSearchParams({ oauth_error: errCode, provider: 'google' });
+				if (email) params.set('email', email);
+				goto(`${redirect}?${params.toString()}`);
 				return;
 			}
 

--- a/web/src/routes/auth/callback/+page.svelte
+++ b/web/src/routes/auth/callback/+page.svelte
@@ -46,15 +46,18 @@
 				} catch (e) {
 					// State unreadable — fall back to /login.
 				}
-				const errCode = data.title || data.detail || 'unknown_error';
+				const errCode = data.detail || data.title || 'unknown_error';
 
-				// Try to extract email from error detail for email_exists
-				if (errCode === 'email_exists' && data.detail) {
+				// Try to extract email from errors for email_exists
+				if (errCode === 'email_exists') {
 					try {
-						const detail = JSON.parse(data.detail);
-						email = detail.email || '';
+						const msg = data.errors?.[0]?.message;
+						if (msg) {
+							const parsed = JSON.parse(msg);
+							email = parsed.email || '';
+						}
 					} catch {
-						// detail is just a string, not JSON
+						// Could not extract email from error
 					}
 				}
 

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -3,8 +3,14 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Eye, EyeOff } from '@lucide/svelte';
+	import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
 	import { goto } from '$app/navigation';
+
+	const urlParams = $derived($page.url.searchParams);
+	const oauthError = $derived(urlParams.get('oauth_error'));
+	const oauthProvider = $derived(urlParams.get('provider') || 'google');
 
 	let email = $state('');
 	let password = $state('');
@@ -14,10 +20,19 @@
 	let isLoading = $state(false);
 	let generalError = $state('');
 
-	const showResetSuccess = $derived($page.url.searchParams.get('reset') === 'success');
+	const showResetSuccess = $derived(urlParams.get('reset') === 'success');
+	const showOAuthExistsError = $derived(oauthError === 'email_exists');
+	const showOAuthCancelled = $derived(oauthError === 'cancelled');
+	const providerLabel = $derived(oauthProvider === 'google' ? 'Google' : oauthProvider);
 
-	if (typeof window !== 'undefined' && localStorage.getItem('access_token')) {
-		goto('/');
+	if (typeof window !== 'undefined') {
+		if (localStorage.getItem('access_token')) {
+			goto('/');
+		}
+		const params = new URLSearchParams(window.location.search);
+		if (params.get('oauth_error') === 'email_exists') {
+			email = params.get('email') || '';
+		}
 	}
 
 	function validateForm(): boolean {
@@ -97,6 +112,24 @@
 			<div class="mb-4 rounded-md bg-green-500/10 p-3 text-sm text-green-600 dark:text-green-400">
 				Password reset successful. You can now sign in with your new password.
 			</div>
+		{/if}
+
+		{#if showOAuthCancelled}
+			<Alert class="mb-4">
+				<TriangleAlert class="h-4 w-4" />
+				<AlertTitle>Sign in cancelled</AlertTitle>
+				<AlertDescription>You cancelled signing in with {providerLabel}. Please try again or use a different method.</AlertDescription>
+			</Alert>
+		{/if}
+
+		{#if showOAuthExistsError}
+			<Alert variant="destructive" class="mb-4">
+				<TriangleAlert class="h-4 w-4" />
+				<AlertTitle>Account already exists</AlertTitle>
+				<AlertDescription>
+					An account with this email already exists. Sign in with your password to link your {providerLabel} account.
+				</AlertDescription>
+			</Alert>
 		{/if}
 
 		<form onsubmit={handleSubmit} class="space-y-5">


### PR DESCRIPTION
## Summary

Implements Issue #84 — OAuth frontend improvements across error UX, email collision handling, and account linking management.

### Backend
- **New API endpoints** (all authenticated):
  - `GET /api/auth/oauth/accounts` — list linked providers with has_password status
  - `DELETE /api/auth/oauth/accounts/{provider}` — unlink with dead-end prevention
  - `GET /api/auth/oauth/accounts/{provider}/status` — check link/unlink viability
- **Token exchange** handles `purpose=link` flow (calls `LinkOAuthAccount`)
- **OAuth callback** preserves user binding for link flow via `CreateAuthorizationCodeWithUserInfoForLink`
- **OAuth link init** accepts `redirect` in body (defaults to `/profile`)
- **email_exists** error includes email + provider in detail field for frontend parsing
- **Fix**: `oauth_accounts.created_at` was always NULL — now set to `NOW()`

### Frontend
- **Toaster** added to root layout (svelte-sonner)
- **Login page**: alerts for `email_exists` (with pre-filled email) and `cancelled` errors
- **Callback page**: passes email through to login redirect on `email_exists` errors
- **Profile page** → full settings hub:
  - Connected Accounts card (Google link/unlink)
  - Unlink confirmation dialog with password-lock warning
  - Set Password section for OAuth-only users
  - Toast notifications for `?linked=google` success and OAuth error query params

### Testing
- All backend tests pass (`make test`)
- Frontend passes `svelte-check` (no new errors)
- Full build succeeds (`make build`)

Close #84 