### PR TITLE
refactor: clean up Makefile — fix .PHONY syntax, remove unused vars, DRY web targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY := start dev run build test test-cover tidy clean web-install web-dev web-build web-preview embed-frontend db-migrate-up db-migrate-down db-migrate-steps db-migrate-force db-migrate-create sqlc-generate
+.PHONY: start dev run build test test-cover tidy clean web-deps web-dev web-build web-preview embed-frontend db-migrate-up db-migrate-down db-migrate-steps db-migrate-force db-migrate-create sqlc-generate
 
 GO ?= go
 PNPM ?= pnpm
@@ -7,13 +7,6 @@ BIN_DIR := bin
 BIN := $(BIN_DIR)/medminder
 CMD := cmd/server/main.go
 WEB_DIR := web
-DB_HOST ?= localhost
-DB_PORT ?= 5432
-DB_USER ?= medminder
-DB_PASSWORD ?= medminder
-DB_NAME ?= medminder
-DB_SSLMODE ?= disable
-MIGRATION_SOURCE ?= file://internal/common/database/migrations
 
 start:
 	@trap 'kill 0' EXIT; \
@@ -44,17 +37,11 @@ tidy:
 clean:
 	rm -rf $(BIN_DIR)
 
-web-install:
+web-deps:
 	cd $(WEB_DIR) && $(PNPM) install
 
-web-dev:
-	cd $(WEB_DIR) && $(PNPM) dev
-
-web-build:
-	cd $(WEB_DIR) && $(PNPM) build
-
-web-preview:
-	cd $(WEB_DIR) && $(PNPM) preview
+web-%: web-deps
+	cd $(WEB_DIR) && $(PNPM) $*
 
 embed-frontend: web-build build
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A medication reminder application built with Go and SvelteKit (shadcn-svelte, Ta
 
 ```bash
 go mod download
-make web-install
+make web-deps
 make start        # Go API on :8080, Vite on :5173
 ```
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -19,7 +19,7 @@
 | Production build | `pnpm build` | `web/` |
 | Type/syntax check | `pnpm check` | `web/` |
 | Preview build | `pnpm preview` | `web/` |
-| Install deps | `make web-install` | root |
+| Install deps | `make web-deps` | root |
 | Full prod build | `make embed-frontend` | root |
 
 ## Code Style


### PR DESCRIPTION
## Summary

- Fix `.PHONY := ` → `.PHONY:` (was setting a variable, not declaring targets)
- Remove unused `DB_*` and `MIGRATION_SOURCE` variables (migration tool reads config file)
- Replace 4 `web-*` explicit targets with `web-%` pattern target
- Add `web-deps` as prerequisite so node_modules is always installed before any web target runs
- Rename `web-install` → `web-deps` for clarity
- Update `README.md` and `docs/frontend.md` references

**File diff:** 82 → 69 lines (+6 / -19)