### PR TITLE
fix: load .env in migration CLI to resolve DB auth failure

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/shuvo-paul/medminder/internal/common/config"
 	"github.com/shuvo-paul/medminder/internal/common/database"
 	"github.com/shuvo-paul/medminder/internal/common/database/migrations"
@@ -22,6 +23,9 @@ func main() {
 	name := flag.String("name", "", "name for migration (required for create)")
 	migrationDir := flag.String("dir", "internal/common/database/migrations", "directory for migration files")
 	flag.Parse()
+
+	// Silently ignore missing .env — exported env vars take precedence.
+	_ = godotenv.Load()
 
 	if *direction == "create" {
 		if *name == "" {


### PR DESCRIPTION
## Problem
`make db-migrate-down` (and other migration commands) failed with `password authentication failed for user "medminder"` because `cmd/migrate/main.go` was missing `godotenv.Load()`.

## Root Cause
`config.Load()` uses `os.LookupEnv` — without loading `.env` first, it falls back to Go-level defaults (e.g. `DB_PORT=5432` instead of `5433` from `.env`). This connected to a different PostgreSQL instance that didn't have the `medminder` user.

The server entrypoint (`cmd/server/main.go:27`) already calls `godotenv.Load()`; the migration CLI didn't.

## Fix
Added `_ = godotenv.Load()` after `flag.Parse()` and before `config.Load()`, plus the `github.com/joho/godotenv` import.