### PR TITLE
feat(auth): add PUT /api/auth/password (change password) endpoint

### DIFF
--- a/internal/features/auth/dto/auth.go
+++ b/internal/features/auth/dto/auth.go
@@ -54,6 +54,7 @@ type ChangePasswordInput struct {
 	Body          struct {
 		CurrentPassword string `json:"current_password" minLength:"1"`
 		NewPassword     string `json:"new_password" minLength:"8"`
+		ConfirmPassword string `json:"confirm_password" minLength:"8"`
 	}
 }
 

--- a/internal/features/auth/dto/auth.go
+++ b/internal/features/auth/dto/auth.go
@@ -48,3 +48,17 @@ type LogoutOutput struct {
 		Message string `json:"message"`
 	}
 }
+
+type ChangePasswordInput struct {
+	Authorization string `header:"Authorization"`
+	Body          struct {
+		CurrentPassword string `json:"current_password" minLength:"1"`
+		NewPassword     string `json:"new_password" minLength:"8"`
+	}
+}
+
+type ChangePasswordOutput struct {
+	Body struct {
+		Message string `json:"message"`
+	}
+}

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -43,6 +43,11 @@ func (m *MockAuthService) SetPassword(ctx context.Context, userID uuid.UUID, pas
 	return args.Error(0)
 }
 
+func (m *MockAuthService) ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error {
+	args := m.Called(ctx, userID, currentPassword, newPassword)
+	return args.Error(0)
+}
+
 type MockTokenService struct {
 	mock.Mock
 }

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -792,6 +792,37 @@ func OAuthLinkStatusHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.O
 	}
 }
 
+// ChangePasswordHandler returns a handler that changes the authenticated user's password.
+// PUT /api/auth/password (authenticated)
+func ChangePasswordHandler(authSvc service.AuthService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.ChangePasswordInput) (*dto.ChangePasswordOutput, error) {
+	return func(ctx context.Context, input *dto.ChangePasswordInput) (*dto.ChangePasswordOutput, error) {
+		userID, err := ExtractUserIDFromAuth(input.Authorization, tokenSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := ValidatePassword(input.Body.NewPassword); err != nil {
+			return nil, huma.Error400BadRequest("invalid new password", err)
+		}
+
+		if err := authSvc.ChangePassword(ctx, userID, input.Body.CurrentPassword, input.Body.NewPassword); err != nil {
+			if errors.Is(err, service.ErrNoPasswordSet) {
+				return nil, huma.Error400BadRequest("no password set", err)
+			}
+			if errors.Is(err, service.ErrWrongPassword) {
+				return nil, huma.Error403Forbidden("current password is incorrect", err)
+			}
+			return nil, huma.Error500InternalServerError("failed to change password", err)
+		}
+
+		return &dto.ChangePasswordOutput{
+			Body: struct {
+				Message string `json:"message"`
+			}{Message: "password changed successfully"},
+		}, nil
+	}
+}
+
 // generateAuthCode creates a cryptographically random authorization code and its SHA-256 hash.
 // Returns the raw code (for the frontend) and the hash (for database storage).
 func generateAuthCode() (rawCode, hash string, err error) {

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -812,6 +812,12 @@ func ChangePasswordHandler(authSvc service.AuthService, tokenSvc service.TokenSe
 			if errors.Is(err, service.ErrWrongPassword) {
 				return nil, huma.Error403Forbidden("current password is incorrect", err)
 			}
+			if errors.Is(err, service.ErrUserNotFound) {
+				return nil, huma.Error404NotFound("user not found", err)
+			}
+			if errors.Is(err, service.ErrSamePassword) {
+				return nil, huma.Error400BadRequest("new password must differ from current password", err)
+			}
 			return nil, huma.Error500InternalServerError("failed to change password", err)
 		}
 

--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -805,6 +805,10 @@ func ChangePasswordHandler(authSvc service.AuthService, tokenSvc service.TokenSe
 			return nil, huma.Error400BadRequest("invalid new password", err)
 		}
 
+		if input.Body.NewPassword != input.Body.ConfirmPassword {
+			return nil, huma.Error400BadRequest("passwords do not match")
+		}
+
 		if err := authSvc.ChangePassword(ctx, userID, input.Body.CurrentPassword, input.Body.NewPassword); err != nil {
 			if errors.Is(err, service.ErrNoPasswordSet) {
 				return nil, huma.Error400BadRequest("no password set", err)

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -809,3 +809,154 @@ func TestSetPasswordHandler_UpdateFailed(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "failed to set password")
 }
+
+func TestChangePasswordHandler_Success(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockAuthSvc := new(MockAuthService)
+	mockAuthSvc.On("ChangePassword", mock.Anything, userID, "CurrentPwd1", "NewPwd123").Return(nil)
+
+	handler := handlers.ChangePasswordHandler(mockAuthSvc, mockTokenSvc)
+
+	input := &dto.ChangePasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.CurrentPassword = "CurrentPwd1"
+	input.Body.NewPassword = "NewPwd123"
+
+	resp, err := handler(context.Background(), input)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "password changed successfully", resp.Body.Message)
+	mockAuthSvc.AssertExpectations(t)
+}
+
+func TestChangePasswordHandler_InvalidToken(t *testing.T) {
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", "bad-token").Return(nil, service.ErrInvalidToken)
+
+	mockAuthSvc := new(MockAuthService)
+
+	handler := handlers.ChangePasswordHandler(mockAuthSvc, mockTokenSvc)
+
+	input := &dto.ChangePasswordInput{
+		Authorization: "Bearer bad-token",
+	}
+	input.Body.CurrentPassword = "CurrentPwd1"
+	input.Body.NewPassword = "NewPwd123"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "Invalid or expired")
+}
+
+func TestChangePasswordHandler_WeakNewPassword(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockAuthSvc := new(MockAuthService)
+
+	handler := handlers.ChangePasswordHandler(mockAuthSvc, mockTokenSvc)
+
+	input := &dto.ChangePasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.CurrentPassword = "CurrentPwd1"
+	input.Body.NewPassword = "short"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "invalid new password")
+	// Verify ChangePassword was never called
+	mockAuthSvc.AssertNotCalled(t, "ChangePassword", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestChangePasswordHandler_WrongCurrentPassword(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockAuthSvc := new(MockAuthService)
+	mockAuthSvc.On("ChangePassword", mock.Anything, userID, "WrongPwd1", "NewPwd123").
+		Return(service.ErrWrongPassword)
+
+	handler := handlers.ChangePasswordHandler(mockAuthSvc, mockTokenSvc)
+
+	input := &dto.ChangePasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.CurrentPassword = "WrongPwd1"
+	input.Body.NewPassword = "NewPwd123"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "current password is incorrect")
+}
+
+func TestChangePasswordHandler_NoPasswordSet(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockAuthSvc := new(MockAuthService)
+	mockAuthSvc.On("ChangePassword", mock.Anything, userID, "CurrentPwd1", "NewPwd123").
+		Return(service.ErrNoPasswordSet)
+
+	handler := handlers.ChangePasswordHandler(mockAuthSvc, mockTokenSvc)
+
+	input := &dto.ChangePasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.CurrentPassword = "CurrentPwd1"
+	input.Body.NewPassword = "NewPwd123"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "no password set")
+}
+
+func TestChangePasswordHandler_ServiceError(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockAuthSvc := new(MockAuthService)
+	mockAuthSvc.On("ChangePassword", mock.Anything, userID, "CurrentPwd1", "NewPwd123").
+		Return(assert.AnError)
+
+	handler := handlers.ChangePasswordHandler(mockAuthSvc, mockTokenSvc)
+
+	input := &dto.ChangePasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.CurrentPassword = "CurrentPwd1"
+	input.Body.NewPassword = "NewPwd123"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to change password")
+}

--- a/internal/features/auth/handlers/oauth_providers_test.go
+++ b/internal/features/auth/handlers/oauth_providers_test.go
@@ -827,6 +827,7 @@ func TestChangePasswordHandler_Success(t *testing.T) {
 	}
 	input.Body.CurrentPassword = "CurrentPwd1"
 	input.Body.NewPassword = "NewPwd123"
+	input.Body.ConfirmPassword = "NewPwd123"
 
 	resp, err := handler(context.Background(), input)
 
@@ -849,6 +850,7 @@ func TestChangePasswordHandler_InvalidToken(t *testing.T) {
 	}
 	input.Body.CurrentPassword = "CurrentPwd1"
 	input.Body.NewPassword = "NewPwd123"
+	input.Body.ConfirmPassword = "NewPwd123"
 
 	resp, err := handler(context.Background(), input)
 
@@ -873,6 +875,7 @@ func TestChangePasswordHandler_WeakNewPassword(t *testing.T) {
 	}
 	input.Body.CurrentPassword = "CurrentPwd1"
 	input.Body.NewPassword = "short"
+	input.Body.ConfirmPassword = "short"
 
 	resp, err := handler(context.Background(), input)
 
@@ -880,6 +883,32 @@ func TestChangePasswordHandler_WeakNewPassword(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "invalid new password")
 	// Verify ChangePassword was never called
+	mockAuthSvc.AssertNotCalled(t, "ChangePassword", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestChangePasswordHandler_PasswordMismatch(t *testing.T) {
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc := new(MockTokenService)
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+
+	mockAuthSvc := new(MockAuthService)
+
+	handler := handlers.ChangePasswordHandler(mockAuthSvc, mockTokenSvc)
+
+	input := &dto.ChangePasswordInput{
+		Authorization: "Bearer " + token,
+	}
+	input.Body.CurrentPassword = "CurrentPwd1"
+	input.Body.NewPassword = "NewPwd123"
+	input.Body.ConfirmPassword = "DifferentPwd1"
+
+	resp, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "passwords do not match")
 	mockAuthSvc.AssertNotCalled(t, "ChangePassword", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
@@ -901,6 +930,7 @@ func TestChangePasswordHandler_WrongCurrentPassword(t *testing.T) {
 	}
 	input.Body.CurrentPassword = "WrongPwd1"
 	input.Body.NewPassword = "NewPwd123"
+	input.Body.ConfirmPassword = "NewPwd123"
 
 	resp, err := handler(context.Background(), input)
 
@@ -927,6 +957,7 @@ func TestChangePasswordHandler_NoPasswordSet(t *testing.T) {
 	}
 	input.Body.CurrentPassword = "CurrentPwd1"
 	input.Body.NewPassword = "NewPwd123"
+	input.Body.ConfirmPassword = "NewPwd123"
 
 	resp, err := handler(context.Background(), input)
 
@@ -953,6 +984,7 @@ func TestChangePasswordHandler_ServiceError(t *testing.T) {
 	}
 	input.Body.CurrentPassword = "CurrentPwd1"
 	input.Body.NewPassword = "NewPwd123"
+	input.Body.ConfirmPassword = "NewPwd123"
 
 	resp, err := handler(context.Background(), input)
 

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -103,4 +103,16 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, auditRepo
 			{"bearer": {}},
 		},
 	}, handlers.SetPasswordHandler(authSvc, tokenSvc))
+
+	// Change password (authenticated) — requires current password
+	huma.Register(api, huma.Operation{
+		OperationID: "change-password",
+		Method:      http.MethodPut,
+		Path:        "/api/auth/password",
+		Summary:     "Change password",
+		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
+	}, handlers.ChangePasswordHandler(authSvc, tokenSvc))
 }

--- a/internal/features/auth/service/auth_service.go
+++ b/internal/features/auth/service/auth_service.go
@@ -38,6 +38,7 @@ type AuthService interface {
 	Login(ctx context.Context, email, password string) (*LoginResult, error)
 	Logout(ctx context.Context, userID uuid.UUID) error
 	SetPassword(ctx context.Context, userID uuid.UUID, password string) error
+	ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error
 }
 
 type authService struct {
@@ -142,6 +143,32 @@ func (s *authService) Logout(ctx context.Context, userID uuid.UUID) error {
 
 func (s *authService) SetPassword(ctx context.Context, userID uuid.UUID, password string) error {
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
+	if err != nil {
+		return fmt.Errorf("hashing password: %w", err)
+	}
+
+	if err := s.userRepo.UpdatePassword(ctx, userID.String(), string(hashedPassword)); err != nil {
+		return fmt.Errorf("updating password: %w", err)
+	}
+
+	return nil
+}
+
+func (s *authService) ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error {
+	user, err := s.userRepo.GetUserByID(ctx, userID.String())
+	if err != nil {
+		return fmt.Errorf("getting user: %w", err)
+	}
+
+	if !user.PasswordHash.Valid || user.PasswordHash.String == "" {
+		return ErrNoPasswordSet
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash.String), []byte(currentPassword)); err != nil {
+		return ErrWrongPassword
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), BcryptCost)
 	if err != nil {
 		return fmt.Errorf("hashing password: %w", err)
 	}

--- a/internal/features/auth/service/auth_service.go
+++ b/internal/features/auth/service/auth_service.go
@@ -157,6 +157,9 @@ func (s *authService) SetPassword(ctx context.Context, userID uuid.UUID, passwor
 func (s *authService) ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error {
 	user, err := s.userRepo.GetUserByID(ctx, userID.String())
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("getting user: %w", ErrUserNotFound)
+		}
 		return fmt.Errorf("getting user: %w", err)
 	}
 
@@ -166,6 +169,10 @@ func (s *authService) ChangePassword(ctx context.Context, userID uuid.UUID, curr
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash.String), []byte(currentPassword)); err != nil {
 		return ErrWrongPassword
+	}
+
+	if currentPassword == newPassword {
+		return ErrSamePassword
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), BcryptCost)

--- a/internal/features/auth/service/auth_service_test.go
+++ b/internal/features/auth/service/auth_service_test.go
@@ -469,7 +469,7 @@ func TestChangePassword(t *testing.T) {
 			},
 			expect: func(t *testing.T, err error) {
 				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "getting user")
+				assert.True(t, errors.Is(err, service.ErrUserNotFound))
 			},
 		},
 		{
@@ -508,6 +508,25 @@ func TestChangePassword(t *testing.T) {
 			expect: func(t *testing.T, err error) {
 				assert.Error(t, err)
 				assert.True(t, errors.Is(err, service.ErrWrongPassword))
+			},
+		},
+		{
+			name: "ChangePassword_SamePassword",
+			input: changePwdInput{
+				userID:          uuid.New(),
+				currentPassword: currentPwd,
+				newPassword:     currentPwd,
+			},
+			setup: func(userRepo *MockUserRepository, input changePwdInput) {
+				userRepo.On("GetUserByID", mock.Anything, input.userID.String()).
+					Return(db.User{
+						ID:           input.userID,
+						PasswordHash: sql.NullString{String: string(hashedCurrent), Valid: true},
+					}, nil)
+			},
+			expect: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, service.ErrSamePassword))
 			},
 		},
 		{

--- a/internal/features/auth/service/auth_service_test.go
+++ b/internal/features/auth/service/auth_service_test.go
@@ -418,3 +418,134 @@ func TestLogout(t *testing.T) {
 		})
 	}
 }
+
+func TestChangePassword(t *testing.T) {
+	currentPwd := "CurrentPwd1"
+	hashedCurrent, _ := bcrypt.GenerateFromPassword([]byte(currentPwd), service.BcryptCost)
+	newPwd := "NewPwd123"
+
+	type changePwdInput struct {
+		userID          uuid.UUID
+		currentPassword string
+		newPassword     string
+	}
+
+	tests := []struct {
+		name   string
+		input  changePwdInput
+		setup  func(*MockUserRepository, changePwdInput)
+		expect func(*testing.T, error)
+	}{
+		{
+			name: "ChangePassword_Success",
+			input: changePwdInput{
+				userID:          uuid.New(),
+				currentPassword: currentPwd,
+				newPassword:     newPwd,
+			},
+			setup: func(userRepo *MockUserRepository, input changePwdInput) {
+				userRepo.On("GetUserByID", mock.Anything, input.userID.String()).
+					Return(db.User{
+						ID:           input.userID,
+						PasswordHash: sql.NullString{String: string(hashedCurrent), Valid: true},
+					}, nil)
+				userRepo.On("UpdatePassword", mock.Anything, input.userID.String(), mock.AnythingOfType("string")).
+					Return(nil)
+			},
+			expect: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "ChangePassword_UserNotFound",
+			input: changePwdInput{
+				userID:          uuid.New(),
+				currentPassword: currentPwd,
+				newPassword:     newPwd,
+			},
+			setup: func(userRepo *MockUserRepository, input changePwdInput) {
+				userRepo.On("GetUserByID", mock.Anything, input.userID.String()).
+					Return(db.User{}, sql.ErrNoRows)
+			},
+			expect: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "getting user")
+			},
+		},
+		{
+			name: "ChangePassword_NoPasswordSet",
+			input: changePwdInput{
+				userID:          uuid.New(),
+				currentPassword: currentPwd,
+				newPassword:     newPwd,
+			},
+			setup: func(userRepo *MockUserRepository, input changePwdInput) {
+				userRepo.On("GetUserByID", mock.Anything, input.userID.String()).
+					Return(db.User{
+						ID:           input.userID,
+						PasswordHash: sql.NullString{Valid: false},
+					}, nil)
+			},
+			expect: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, service.ErrNoPasswordSet))
+			},
+		},
+		{
+			name: "ChangePassword_WrongCurrentPassword",
+			input: changePwdInput{
+				userID:          uuid.New(),
+				currentPassword: "WrongPwd1",
+				newPassword:     newPwd,
+			},
+			setup: func(userRepo *MockUserRepository, input changePwdInput) {
+				userRepo.On("GetUserByID", mock.Anything, input.userID.String()).
+					Return(db.User{
+						ID:           input.userID,
+						PasswordHash: sql.NullString{String: string(hashedCurrent), Valid: true},
+					}, nil)
+			},
+			expect: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, service.ErrWrongPassword))
+			},
+		},
+		{
+			name: "ChangePassword_UpdateFails",
+			input: changePwdInput{
+				userID:          uuid.New(),
+				currentPassword: currentPwd,
+				newPassword:     newPwd,
+			},
+			setup: func(userRepo *MockUserRepository, input changePwdInput) {
+				userRepo.On("GetUserByID", mock.Anything, input.userID.String()).
+					Return(db.User{
+						ID:           input.userID,
+						PasswordHash: sql.NullString{String: string(hashedCurrent), Valid: true},
+					}, nil)
+				userRepo.On("UpdatePassword", mock.Anything, input.userID.String(), mock.AnythingOfType("string")).
+					Return(errors.New("database error"))
+			},
+			expect: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "updating password")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userRepo := new(MockUserRepository)
+			tokenRepo := new(MockRefreshTokenRepository)
+			tokenSvc := new(MockTokenService)
+			authSvc := service.NewAuthService(userRepo, tokenRepo, tokenSvc)
+
+			tt.setup(userRepo, tt.input)
+
+			err := authSvc.ChangePassword(context.Background(), tt.input.userID, tt.input.currentPassword, tt.input.newPassword)
+
+			tt.expect(t, err)
+			userRepo.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/features/auth/service/errors.go
+++ b/internal/features/auth/service/errors.go
@@ -19,4 +19,6 @@ var (
 	ErrNoPasswordSet         = fmt.Errorf("%w: %w", errors.New("user has no password set"), commonerrors.ErrBadRequest)
 	ErrAccountWillBeLocked   = fmt.Errorf("%w: %w", errors.New("account will be locked out"), commonerrors.ErrForbidden)
 	ErrProviderAlreadyLinked = fmt.Errorf("%w: %w", errors.New("provider already linked"), commonerrors.ErrConflict)
+	ErrUserNotFound          = fmt.Errorf("%w: %w", errors.New("user not found"), commonerrors.ErrNotFound)
+	ErrSamePassword          = fmt.Errorf("%w: %w", errors.New("new password must differ from current password"), commonerrors.ErrBadRequest)
 )

--- a/internal/features/auth/service/errors.go
+++ b/internal/features/auth/service/errors.go
@@ -15,6 +15,8 @@ var (
 	ErrEmailNotFound         = fmt.Errorf("%w: %w", errors.New("email not found"), commonerrors.ErrNotFound)
 	ErrOAuthProviderError    = errors.New("oauth provider error")
 	ErrOAuthProviderFailed   = fmt.Errorf("%w: %w", ErrOAuthProviderError, commonerrors.ErrInternal)
+	ErrWrongPassword         = fmt.Errorf("%w: %w", errors.New("current password is incorrect"), commonerrors.ErrForbidden)
+	ErrNoPasswordSet         = fmt.Errorf("%w: %w", errors.New("user has no password set"), commonerrors.ErrBadRequest)
 	ErrAccountWillBeLocked   = fmt.Errorf("%w: %w", errors.New("account will be locked out"), commonerrors.ErrForbidden)
 	ErrProviderAlreadyLinked = fmt.Errorf("%w: %w", errors.New("provider already linked"), commonerrors.ErrConflict)
 )


### PR DESCRIPTION
**What**: Adds `PUT /api/auth/password` for authenticated users to change their password with current password confirmation.

## Changes
- New `ChangePassword` method on `AuthService` — fetches user, verifies current password bcrypt match, hashes new password, updates via repo
- New errors: `ErrWrongPassword` (403), `ErrNoPasswordSet` (400) for OAuth-only users
- New handler `ChangePasswordHandler` with validation
- Route registered at `PUT /api/auth/password` (authenticated)

## Error mapping
| Condition | Status |
|---|---|
| Invalid/expired token | 401 |
| No password set (OAuth user) | 400 |
| Weak new password | 400 |
| Current password wrong | 403 |
| Service error | 500 |

## Testing
- 5 service tests: success, user not found, no password set, wrong password, update failure
- 6 handler tests: success, invalid token, weak password, wrong password, no password set, service error

Closes REQ-OAUTH-011