### PR TITLE
feat: rename /profile route to /account

### DIFF
--- a/internal/features/auth/handlers/oauth_providers.go
+++ b/internal/features/auth/handlers/oauth_providers.go
@@ -571,7 +571,7 @@ func OAuthLinkInitHandler(deps *OAuthHandlerDeps) func(context.Context, *dto.OAu
 			return nil, huma.Error400BadRequest("invalid redirect URL", errors.New("redirect must be a relative path"))
 		}
 		if redirect == "" {
-			redirect = "/profile"
+			redirect = "/account"
 		}
 
 		state := dto.OAuthState{

--- a/web/src/lib/components/BottomNav.svelte
+++ b/web/src/lib/components/BottomNav.svelte
@@ -12,7 +12,7 @@
 		{ href: '/medications', label: 'Medications', icon: Pill, match: (p: string) => p.startsWith('/medications') },
 		{ href: '/schedule', label: 'Schedule', icon: CalendarClock, match: (p: string) => p.startsWith('/schedule') },
 		{ href: '/profiles', label: 'Profiles', icon: UsersRound, match: (p: string) => p.startsWith('/profiles') },
-		{ href: '/profile', label: 'Account', icon: UserRound, match: (p: string) => p.startsWith('/profile') },
+		{ href: '/account', label: 'Account', icon: UserRound, match: (p: string) => p.startsWith('/account') },
 	];
 </script>
 

--- a/web/src/routes/(protected)/account/+page.svelte
+++ b/web/src/routes/(protected)/account/+page.svelte
@@ -102,7 +102,7 @@
 					'Content-Type': 'application/json',
 					Authorization: `Bearer ${getToken()}`,
 				},
-				body: JSON.stringify({ redirect: '/profile' }),
+				body: JSON.stringify({ redirect: '/account' }),
 			});
 			if (!res.ok) {
 				toast.error('Failed to initiate link');

--- a/web/src/routes/auth/verify-updated/+page.svelte
+++ b/web/src/routes/auth/verify-updated/+page.svelte
@@ -62,7 +62,7 @@
 			status = 'success';
 
 			setTimeout(() => {
-				goto('/profile');
+				goto('/account');
 			}, 2000);
 		} catch {
 			errorMessage = 'Network error. Please check your connection and try again.';
@@ -108,7 +108,7 @@
 					</div>
 
 					<p class="text-center text-sm text-muted-foreground">
-						<a href="/profile" class="text-primary hover:underline">Back to settings</a>
+						<a href="/account" class="text-primary hover:underline">Back to settings</a>
 					</p>
 				</CardContent>
 			</Card>


### PR DESCRIPTION
Renames the user account settings route from `/profile` to `/account` to disambiguate from medication `/profiles`.

- Rename route directory `profile/` → `account/`
- Update `BottomNav.svelte` link and match pattern
- Update OAuth redirect default in `oauth_providers.go`
- Update OAuth link-init redirect payload
- Update `verify-updated/+page.svelte` redirect and link