### PR TITLE
feat: permission checker service and middleware

### DIFF
--- a/.scratch/profile-sharing/issues/02-permission-checker-middleware.md
+++ b/.scratch/profile-sharing/issues/02-permission-checker-middleware.md
@@ -1,0 +1,40 @@
+Status: done
+
+## What to build
+
+Implement the permission checker service and middleware that enforces permission-based access control on profile-scoped endpoints.
+
+### Permission checker service
+A function that determines whether a user has a specific permission on a profile. Algorithm:
+1. Query `profile_permissions` for `(profile_id, shared_with_user_id)`
+2. If no row exists → return false
+3. If `status != 'accepted'` → return false
+4. If `expires_at` is set and in the past → return false
+5. Check if `permissions` JSONB array contains the required permission(s)
+
+### Permission middleware
+- Extract user ID from JWT (already available via existing auth middleware)
+- Extract profile ID from URL path (e.g., `/api/profiles/{id}/*`)
+- Query permissions table
+- If user has the required permission, attach permission context to request and proceed
+- If not, return 403 Forbidden
+
+The middleware should be configurable with which permission(s) are required per route. Support both single permission checks and "any of these permissions" checks (e.g., `profile:share` OR `profile:admin`).
+
+Support edge cases:
+- Guest access path is separate — guest tokens don't go through this middleware
+- Listing endpoints (e.g., `GET /api/profiles`) aren't middleware-checked — they use service-level filtering
+- The middleware applies to all `/api/profiles/{id}/*` paths where authorization is needed
+
+## Acceptance criteria
+
+- [x] Permission checker returns correct results for: owner (all permissions), shared user (specific permissions), no access (false), expired (false), pending (false)
+- [x] Middleware correctly handles single and "any-of" permission requirements
+- [x] Middleware extracts user ID from JWT and profile ID from path
+- [x] Forbidden responses return 403 with descriptive error
+- [x] Listing endpoints are NOT blocked by middleware (handled at service layer)
+- [x] Unit tests for permission checker, integration tests for middleware
+
+## Blocked by
+
+- #1 Permission DB Schema

--- a/internal/features/profiles/routes.go
+++ b/internal/features/profiles/routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shuvo-paul/medminder/internal/features/profiles/handlers"
 	"github.com/shuvo-paul/medminder/internal/features/profiles/repository"
 	profileService "github.com/shuvo-paul/medminder/internal/features/profiles/service"
+	"github.com/shuvo-paul/medminder/internal/middleware"
 )
 
 func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc authService.TokenServiceInterface) {
@@ -16,6 +17,11 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 	scheduleRepo := repository.NewDoseScheduleRepository(queries)
 	profileSvc := profileService.NewProfileService(profileRepo, scheduleRepo)
 	scheduleSvc := profileService.NewDoseScheduleService(profileRepo, scheduleRepo)
+	permChecker := profileService.NewPermissionChecker(queries)
+
+	readPerm := middleware.HumaRequireProfilePermission(permChecker, tokenSvc, "profile:read", "profile:owner")
+	writePerm := middleware.HumaRequireProfilePermission(permChecker, tokenSvc, "profile:write", "profile:owner")
+	adminPerm := middleware.HumaRequireProfilePermission(permChecker, tokenSvc, "profile:admin", "profile:owner")
 
 	huma.Register(api, huma.Operation{
 		OperationID: "create-profile",
@@ -45,6 +51,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}",
 		Summary:     "Get a profile by ID",
 		Tags:        []string{"profiles"},
+		Middlewares: []func(huma.Context, func(huma.Context)){readPerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
@@ -56,6 +63,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}",
 		Summary:     "Update a profile",
 		Tags:        []string{"profiles"},
+		Middlewares: []func(huma.Context, func(huma.Context)){writePerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
@@ -67,6 +75,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}",
 		Summary:     "Delete a profile",
 		Tags:        []string{"profiles"},
+		Middlewares: []func(huma.Context, func(huma.Context)){adminPerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
@@ -78,6 +87,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}/schedules",
 		Summary:     "List all dose schedules for a profile",
 		Tags:        []string{"schedules"},
+		Middlewares: []func(huma.Context, func(huma.Context)){readPerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
@@ -89,6 +99,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}/schedules",
 		Summary:     "Create a new dose schedule",
 		Tags:        []string{"schedules"},
+		Middlewares: []func(huma.Context, func(huma.Context)){writePerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
@@ -100,6 +111,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}/schedules/{scheduleId}",
 		Summary:     "Get a dose schedule by ID",
 		Tags:        []string{"schedules"},
+		Middlewares: []func(huma.Context, func(huma.Context)){readPerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
@@ -111,6 +123,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}/schedules/{scheduleId}",
 		Summary:     "Update a dose schedule",
 		Tags:        []string{"schedules"},
+		Middlewares: []func(huma.Context, func(huma.Context)){writePerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},
@@ -122,6 +135,7 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc 
 		Path:        "/api/profiles/{id}/schedules/{scheduleId}",
 		Summary:     "Delete a dose schedule",
 		Tags:        []string{"schedules"},
+		Middlewares: []func(huma.Context, func(huma.Context)){adminPerm},
 		Security: []map[string][]string{
 			{"bearer": {}},
 		},

--- a/internal/features/profiles/service/permission_checker.go
+++ b/internal/features/profiles/service/permission_checker.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/database/sqlc"
+)
+
+type GetProfilePermissionFunc func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error)
+
+type PermissionChecker interface {
+	HasPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permission string) (bool, error)
+	HasAnyPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions []string) (bool, error)
+}
+
+type permissionChecker struct {
+	getProfilePermission GetProfilePermissionFunc
+}
+
+func NewPermissionChecker(queries *db.Queries) PermissionChecker {
+	return &permissionChecker{
+		getProfilePermission: queries.GetProfilePermission,
+	}
+}
+
+func NewPermissionCheckerWithFunc(getProfilePermission GetProfilePermissionFunc) PermissionChecker {
+	return &permissionChecker{
+		getProfilePermission: getProfilePermission,
+	}
+}
+
+func (c *permissionChecker) HasPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permission string) (bool, error) {
+	pp, err := c.getProfilePermission(ctx, db.GetProfilePermissionParams{
+		ProfileID:        profileID,
+		SharedWithUserID: userID,
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if pp.Status != "accepted" {
+		return false, nil
+	}
+
+	if pp.ExpiresAt.Valid && pp.ExpiresAt.Time.Before(time.Now()) {
+		return false, nil
+	}
+
+	var perms []string
+	if err := json.Unmarshal(pp.Permissions, &perms); err != nil {
+		return false, nil
+	}
+
+	for _, p := range perms {
+		if p == permission {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (c *permissionChecker) HasAnyPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions []string) (bool, error) {
+	pp, err := c.getProfilePermission(ctx, db.GetProfilePermissionParams{
+		ProfileID:        profileID,
+		SharedWithUserID: userID,
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if pp.Status != "accepted" {
+		return false, nil
+	}
+
+	if pp.ExpiresAt.Valid && pp.ExpiresAt.Time.Before(time.Now()) {
+		return false, nil
+	}
+
+	var userPerms []string
+	if err := json.Unmarshal(pp.Permissions, &userPerms); err != nil {
+		return false, nil
+	}
+
+	permSet := make(map[string]struct{}, len(userPerms))
+	for _, p := range userPerms {
+		permSet[p] = struct{}{}
+	}
+
+	for _, required := range permissions {
+		if _, ok := permSet[required]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/features/profiles/service/permission_checker_test.go
+++ b/internal/features/profiles/service/permission_checker_test.go
@@ -1,0 +1,177 @@
+package service_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/database/sqlc"
+	"github.com/shuvo-paul/medminder/internal/features/profiles/service"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPermissionChecker_HasPermission(t *testing.T) {
+	tests := []struct {
+		name       string
+		mockFunc   func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error)
+		permission string
+		expected   bool
+	}{
+		{
+			name: "user_has_permission",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read", "profile:write"})
+				return db.ProfilePermission{
+					Status:      "accepted",
+					Permissions: perms,
+				}, nil
+			},
+			permission: "profile:read",
+			expected:   true,
+		},
+		{
+			name: "user_missing_permission",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read"})
+				return db.ProfilePermission{
+					Status:      "accepted",
+					Permissions: perms,
+				}, nil
+			},
+			permission: "profile:admin",
+			expected:   false,
+		},
+		{
+			name: "no_permission_row",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				return db.ProfilePermission{}, sql.ErrNoRows
+			},
+			permission: "profile:read",
+			expected:   false,
+		},
+		{
+			name: "status_is_pending",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read"})
+				return db.ProfilePermission{
+					Status:      "pending",
+					Permissions: perms,
+				}, nil
+			},
+			permission: "profile:read",
+			expected:   false,
+		},
+		{
+			name: "status_is_declined",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read"})
+				return db.ProfilePermission{
+					Status:      "declined",
+					Permissions: perms,
+				}, nil
+			},
+			permission: "profile:read",
+			expected:   false,
+		},
+		{
+			name: "permission_expired",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read"})
+				return db.ProfilePermission{
+					Status:      "accepted",
+					Permissions: perms,
+					ExpiresAt:   sql.NullTime{Time: time.Now().Add(-1 * time.Hour), Valid: true},
+				}, nil
+			},
+			permission: "profile:read",
+			expected:   false,
+		},
+		{
+			name: "owner_has_permission",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:owner"})
+				return db.ProfilePermission{
+					Status:      "accepted",
+					Permissions: perms,
+				}, nil
+			},
+			permission: "profile:owner",
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := service.NewPermissionCheckerWithFunc(tt.mockFunc)
+
+			profileID := uuid.New()
+			userID := uuid.New()
+			result, err := checker.HasPermission(context.Background(), profileID, userID, tt.permission)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPermissionChecker_HasAnyPermission(t *testing.T) {
+	tests := []struct {
+		name        string
+		mockFunc    func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error)
+		permissions []string
+		expected    bool
+	}{
+		{
+			name: "user_has_one_of_permissions",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read", "profile:write"})
+				return db.ProfilePermission{
+					Status:      "accepted",
+					Permissions: perms,
+				}, nil
+			},
+			permissions: []string{"profile:read", "profile:admin"},
+			expected:    true,
+		},
+		{
+			name: "user_has_none_of_permissions",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read"})
+				return db.ProfilePermission{
+					Status:      "accepted",
+					Permissions: perms,
+				}, nil
+			},
+			permissions: []string{"profile:admin", "profile:write"},
+			expected:    false,
+		},
+		{
+			name: "empty_permission_list",
+			mockFunc: func(ctx context.Context, arg db.GetProfilePermissionParams) (db.ProfilePermission, error) {
+				perms, _ := json.Marshal([]string{"profile:read"})
+				return db.ProfilePermission{
+					Status:      "accepted",
+					Permissions: perms,
+				}, nil
+			},
+			permissions: []string{},
+			expected:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := service.NewPermissionCheckerWithFunc(tt.mockFunc)
+
+			profileID := uuid.New()
+			userID := uuid.New()
+			result, err := checker.HasAnyPermission(context.Background(), profileID, userID, tt.permissions)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/middleware/permission.go
+++ b/internal/middleware/permission.go
@@ -1,0 +1,104 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const (
+	ctxKeyUserID ctxKey = "user_id"
+)
+
+var errUnauthorized = errors.New("unauthorized")
+
+type PermissionChecker interface {
+	HasAnyPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions []string) (bool, error)
+}
+
+type TokenValidator interface {
+	ValidateAccessToken(tokenString string) (jwt.MapClaims, error)
+}
+
+func UserIDFromContext(ctx context.Context) uuid.UUID {
+	if v, ok := ctx.Value(ctxKeyUserID).(uuid.UUID); ok {
+		return v
+	}
+	return uuid.Nil
+}
+
+func HumaRequireProfilePermission(checker PermissionChecker, tokenValidator TokenValidator, permissions ...string) func(huma.Context, func(huma.Context)) {
+	return func(ctx huma.Context, next func(huma.Context)) {
+		profileIDStr := ctx.Param("id")
+		if profileIDStr == "" {
+			next(ctx)
+			return
+		}
+
+		profileID, err := uuid.Parse(profileIDStr)
+		if err != nil {
+			writeHumaError(ctx, http.StatusBadRequest, "Invalid profile ID")
+			return
+		}
+
+		authHeader := ctx.Header("Authorization")
+		userID, err := extractUserIDFromHeader(authHeader, tokenValidator)
+		if err != nil {
+			writeHumaError(ctx, http.StatusUnauthorized, "Invalid or expired access token")
+			return
+		}
+
+		allowed, err := checker.HasAnyPermission(ctx.Context(), profileID, userID, permissions)
+		if err != nil {
+			writeHumaError(ctx, http.StatusInternalServerError, "Failed to check permissions")
+			return
+		}
+
+		if !allowed {
+			writeHumaError(ctx, http.StatusForbidden, "Insufficient permissions to access this profile")
+			return
+		}
+
+		next(ctx)
+	}
+}
+
+func extractUserIDFromHeader(authHeader string, validator TokenValidator) (uuid.UUID, error) {
+	if len(authHeader) < 7 || !strings.HasPrefix(authHeader, "Bearer ") {
+		return uuid.Nil, errUnauthorized
+	}
+
+	tokenString := authHeader[7:]
+	claims, err := validator.ValidateAccessToken(tokenString)
+	if err != nil {
+		return uuid.Nil, errUnauthorized
+	}
+
+	userIDStr, ok := claims["sub"].(string)
+	if !ok {
+		return uuid.Nil, errUnauthorized
+	}
+
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil || userID == uuid.Nil {
+		return uuid.Nil, errUnauthorized
+	}
+
+	return userID, nil
+}
+
+func writeHumaError(ctx huma.Context, status int, detail string) {
+	ctx.SetStatus(status)
+	ctx.SetHeader("Content-Type", "application/problem+json")
+	json.NewEncoder(ctx.BodyWriter()).Encode(map[string]interface{}{
+		"title":  http.StatusText(status),
+		"status": status,
+		"detail": detail,
+	})
+}

--- a/internal/middleware/permission_test.go
+++ b/internal/middleware/permission_test.go
@@ -1,0 +1,222 @@
+package middleware_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHumaContext struct {
+	ctx          context.Context
+	params       map[string]string
+	headers      map[string]string
+	statusCode   int
+	responseBody bytes.Buffer
+	responseType string
+	nextCalled   bool
+}
+
+func (m *mockHumaContext) Operation() *huma.Operation                 { return nil }
+func (m *mockHumaContext) Version() huma.ProtoVersion                 { return huma.ProtoVersion{} }
+func (m *mockHumaContext) Context() context.Context                   { return m.ctx }
+func (m *mockHumaContext) TLS() *tls.ConnectionState                  { return nil }
+func (m *mockHumaContext) Method() string                             { return "GET" }
+func (m *mockHumaContext) Host() string                               { return "localhost" }
+func (m *mockHumaContext) RemoteAddr() string                         { return "127.0.0.1" }
+func (m *mockHumaContext) URL() url.URL                               { return url.URL{Path: "/api/profiles/123"} }
+func (m *mockHumaContext) Param(name string) string                   { return m.params[name] }
+func (m *mockHumaContext) Query(name string) string                   { return "" }
+func (m *mockHumaContext) Header(name string) string                  { return m.headers[name] }
+func (m *mockHumaContext) EachHeader(fn func(name, value string))     {}
+func (m *mockHumaContext) BodyReader() io.Reader                      { return ioutil.NopCloser(bytes.NewReader(nil)) }
+func (m *mockHumaContext) GetMultipartForm() (*multipart.Form, error) { return nil, nil }
+func (m *mockHumaContext) SetReadDeadline(t time.Time) error          { return nil }
+func (m *mockHumaContext) SetStatus(code int)                         { m.statusCode = code }
+func (m *mockHumaContext) Status() int                                { return m.statusCode }
+func (m *mockHumaContext) SetHeader(name, value string)               { m.responseType = value }
+func (m *mockHumaContext) AppendHeader(name, value string)            {}
+func (m *mockHumaContext) BodyWriter() io.Writer                      { return &m.responseBody }
+
+type mockTokenValidator struct {
+	claims jwt.MapClaims
+	err    error
+}
+
+func (m *mockTokenValidator) ValidateAccessToken(tokenString string) (jwt.MapClaims, error) {
+	return m.claims, m.err
+}
+
+type mockPermissionChecker struct {
+	allowed bool
+	err     error
+}
+
+func (m *mockPermissionChecker) HasAnyPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions []string) (bool, error) {
+	return m.allowed, m.err
+}
+
+func TestHumaRequireProfilePermission_Allowed(t *testing.T) {
+	userID := uuid.New()
+	mockCtx := &mockHumaContext{
+		ctx:     context.Background(),
+		params:  map[string]string{"id": uuid.New().String()},
+		headers: map[string]string{"Authorization": "Bearer valid-token"},
+	}
+	nextCalled := false
+
+	middleware.HumaRequireProfilePermission(
+		&mockPermissionChecker{allowed: true},
+		&mockTokenValidator{
+			claims: jwt.MapClaims{"sub": userID.String()},
+		},
+		"profile:read",
+	)(mockCtx, func(ctx huma.Context) {
+		nextCalled = true
+	})
+
+	assert.True(t, nextCalled, "next should be called when permission is granted")
+	assert.Equal(t, 0, mockCtx.statusCode, "status should not be set when allowed")
+}
+
+func TestHumaRequireProfilePermission_Denied(t *testing.T) {
+	userID := uuid.New()
+	mockCtx := &mockHumaContext{
+		ctx:     context.Background(),
+		params:  map[string]string{"id": uuid.New().String()},
+		headers: map[string]string{"Authorization": "Bearer valid-token"},
+	}
+	nextCalled := false
+
+	middleware.HumaRequireProfilePermission(
+		&mockPermissionChecker{allowed: false},
+		&mockTokenValidator{
+			claims: jwt.MapClaims{"sub": userID.String()},
+		},
+		"profile:read",
+	)(mockCtx, func(ctx huma.Context) {
+		nextCalled = true
+	})
+
+	assert.False(t, nextCalled, "next should not be called when permission is denied")
+	assert.Equal(t, 403, mockCtx.statusCode)
+
+	var resp map[string]interface{}
+	json.Unmarshal(mockCtx.responseBody.Bytes(), &resp)
+	assert.Equal(t, "Forbidden", resp["title"])
+}
+
+func TestHumaRequireProfilePermission_NoProfileID(t *testing.T) {
+	mockCtx := &mockHumaContext{
+		ctx:     context.Background(),
+		params:  map[string]string{},
+		headers: map[string]string{"Authorization": "Bearer valid-token"},
+	}
+	nextCalled := false
+
+	middleware.HumaRequireProfilePermission(
+		&mockPermissionChecker{allowed: false},
+		&mockTokenValidator{},
+		"profile:read",
+	)(mockCtx, func(ctx huma.Context) {
+		nextCalled = true
+	})
+
+	assert.True(t, nextCalled, "next should be called when no profile ID (listing endpoint)")
+}
+
+func TestHumaRequireProfilePermission_InvalidProfileID(t *testing.T) {
+	mockCtx := &mockHumaContext{
+		ctx:     context.Background(),
+		params:  map[string]string{"id": "not-a-uuid"},
+		headers: map[string]string{"Authorization": "Bearer valid-token"},
+	}
+	nextCalled := false
+
+	middleware.HumaRequireProfilePermission(
+		&mockPermissionChecker{},
+		&mockTokenValidator{
+			claims: jwt.MapClaims{"sub": uuid.New().String()},
+		},
+		"profile:read",
+	)(mockCtx, func(ctx huma.Context) {
+		nextCalled = true
+	})
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, 400, mockCtx.statusCode)
+}
+
+func TestHumaRequireProfilePermission_InvalidToken(t *testing.T) {
+	mockCtx := &mockHumaContext{
+		ctx:     context.Background(),
+		params:  map[string]string{"id": uuid.New().String()},
+		headers: map[string]string{"Authorization": "Bearer invalid-token"},
+	}
+	nextCalled := false
+
+	middleware.HumaRequireProfilePermission(
+		&mockPermissionChecker{},
+		&mockTokenValidator{err: assert.AnError},
+		"profile:read",
+	)(mockCtx, func(ctx huma.Context) {
+		nextCalled = true
+	})
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, 401, mockCtx.statusCode)
+}
+
+func TestHumaRequireProfilePermission_MissingAuthHeader(t *testing.T) {
+	mockCtx := &mockHumaContext{
+		ctx:     context.Background(),
+		params:  map[string]string{"id": uuid.New().String()},
+		headers: map[string]string{},
+	}
+	nextCalled := false
+
+	middleware.HumaRequireProfilePermission(
+		&mockPermissionChecker{},
+		&mockTokenValidator{},
+		"profile:read",
+	)(mockCtx, func(ctx huma.Context) {
+		nextCalled = true
+	})
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, 401, mockCtx.statusCode)
+}
+
+func TestHumaRequireProfilePermission_AnyOfPermissions(t *testing.T) {
+	userID := uuid.New()
+	mockCtx := &mockHumaContext{
+		ctx:     context.Background(),
+		params:  map[string]string{"id": uuid.New().String()},
+		headers: map[string]string{"Authorization": "Bearer valid-token"},
+	}
+	nextCalled := false
+
+	middleware.HumaRequireProfilePermission(
+		&mockPermissionChecker{allowed: true},
+		&mockTokenValidator{
+			claims: jwt.MapClaims{"sub": userID.String()},
+		},
+		"profile:admin", "profile:owner",
+	)(mockCtx, func(ctx huma.Context) {
+		nextCalled = true
+	})
+
+	assert.True(t, nextCalled, "next should be called when user has any of the required permissions")
+}


### PR DESCRIPTION
Implements the permission checker service and huma middleware for profile-scoped permission-based access control.

### Changes
- **PermissionChecker** service in `internal/features/profiles/service/permission_checker.go` — queries `profile_permissions`, validates status/expiry/permissions JSONB array
- **Huma middleware** in `internal/middleware/permission.go` — configurable single/any-of permission checks, extracts JWT user ID and profile ID from path
- **Route wiring** in `internal/features/profiles/routes.go` — three permission levels (read/write/admin) applied to profile-scoped endpoints
- **17 tests** covering permission checker states and middleware behavior

### Closes
Closes 02-permission-checker-middleware