### PR TITLE
feat(profiles): replace owner_user_id with permission model

### DIFF
--- a/internal/database/sqlc/profiles.sql.go
+++ b/internal/database/sqlc/profiles.sql.go
@@ -183,7 +183,7 @@ const listProfilesByUser = `-- name: ListProfilesByUser :many
 SELECT p.id, p.name, p.date_of_birth, p.timezone, p.created_at, p.updated_at
 FROM profiles p
 INNER JOIN profile_permissions pp ON pp.profile_id = p.id
-WHERE pp.shared_with_user_id = $1 AND pp.status = 'accepted'
+WHERE pp.shared_with_user_id = $1 AND pp.status = 'accepted' AND (pp.expires_at IS NULL OR pp.expires_at > NOW())
 ORDER BY p.created_at DESC
 `
 

--- a/internal/database/sqlc/profiles.sql.go
+++ b/internal/database/sqlc/profiles.sql.go
@@ -183,7 +183,7 @@ const listProfilesByUser = `-- name: ListProfilesByUser :many
 SELECT p.id, p.name, p.date_of_birth, p.timezone, p.created_at, p.updated_at
 FROM profiles p
 INNER JOIN profile_permissions pp ON pp.profile_id = p.id
-WHERE pp.shared_with_user_id = $1
+WHERE pp.shared_with_user_id = $1 AND pp.status = 'accepted'
 ORDER BY p.created_at DESC
 `
 

--- a/internal/database/sqlc/queries/profiles.sql
+++ b/internal/database/sqlc/queries/profiles.sql
@@ -17,7 +17,7 @@ WHERE id = $1;
 SELECT p.id, p.name, p.date_of_birth, p.timezone, p.created_at, p.updated_at
 FROM profiles p
 INNER JOIN profile_permissions pp ON pp.profile_id = p.id
-WHERE pp.shared_with_user_id = $1
+WHERE pp.shared_with_user_id = $1 AND pp.status = 'accepted'
 ORDER BY p.created_at DESC;
 
 -- name: UpdateProfile :one

--- a/internal/database/sqlc/queries/profiles.sql
+++ b/internal/database/sqlc/queries/profiles.sql
@@ -17,7 +17,7 @@ WHERE id = $1;
 SELECT p.id, p.name, p.date_of_birth, p.timezone, p.created_at, p.updated_at
 FROM profiles p
 INNER JOIN profile_permissions pp ON pp.profile_id = p.id
-WHERE pp.shared_with_user_id = $1 AND pp.status = 'accepted'
+WHERE pp.shared_with_user_id = $1 AND pp.status = 'accepted' AND (pp.expires_at IS NULL OR pp.expires_at > NOW())
 ORDER BY p.created_at DESC;
 
 -- name: UpdateProfile :one

--- a/internal/features/profiles/dto/profile.go
+++ b/internal/features/profiles/dto/profile.go
@@ -21,6 +21,7 @@ type ProfileDTO struct {
 	Name        string            `json:"name"`
 	DateOfBirth *string           `json:"date_of_birth"`
 	Timezone    string            `json:"timezone"`
+	IsOwner     bool              `json:"is_owner"`
 	CreatedAt   time.Time         `json:"created_at"`
 	UpdatedAt   time.Time         `json:"updated_at"`
 	Schedules   []DoseScheduleDTO `json:"schedules"`

--- a/internal/features/profiles/handlers/mocks_test.go
+++ b/internal/features/profiles/handlers/mocks_test.go
@@ -14,8 +14,8 @@ type MockProfileService struct {
 	mock.Mock
 }
 
-func (m *MockProfileService) CreateProfile(ctx context.Context, name string, dateOfBirth *time.Time, timezone string, schedules []service.DoseScheduleInput) (*service.ProfileResult, error) {
-	args := m.Called(ctx, name, dateOfBirth, timezone, schedules)
+func (m *MockProfileService) CreateProfile(ctx context.Context, userID uuid.UUID, name string, dateOfBirth *time.Time, timezone string, schedules []service.DoseScheduleInput) (*service.ProfileResult, error) {
+	args := m.Called(ctx, userID, name, dateOfBirth, timezone, schedules)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/features/profiles/handlers/profile.go
+++ b/internal/features/profiles/handlers/profile.go
@@ -18,7 +18,7 @@ type TokenServiceInterface interface {
 
 func CreateProfileHandler(svc service.ProfileService, tokenSvc TokenServiceInterface) func(context.Context, *dto.CreateProfileInput) (*dto.CreateProfileOutput, error) {
 	return func(ctx context.Context, input *dto.CreateProfileInput) (*dto.CreateProfileOutput, error) {
-		_, err := ExtractUserIDFromAuth(input.Authorization, tokenSvc)
+		userID, err := ExtractUserIDFromAuth(input.Authorization, tokenSvc)
 		if err != nil {
 			return nil, err
 		}
@@ -37,7 +37,7 @@ func CreateProfileHandler(svc service.ProfileService, tokenSvc TokenServiceInter
 			schedules[i] = service.DoseScheduleInput{Name: s.Name, Time: s.Time}
 		}
 
-		result, err := svc.CreateProfile(ctx, input.Body.Name, dateOfBirth, input.Body.Timezone, schedules)
+		result, err := svc.CreateProfile(ctx, userID, input.Body.Name, dateOfBirth, input.Body.Timezone, schedules)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidTimezone) {
 				return nil, huma.Error400BadRequest("Invalid timezone", err)
@@ -204,6 +204,7 @@ func toProfileDTO(p service.ProfileDTO) dto.ProfileDTO {
 		ID:        p.ID,
 		Name:      p.Name,
 		Timezone:  p.Timezone,
+		IsOwner:   p.IsOwner,
 		CreatedAt: p.CreatedAt,
 		UpdatedAt: p.UpdatedAt,
 		Schedules: make([]dto.DoseScheduleDTO, len(p.Schedules)),

--- a/internal/features/profiles/handlers/profile_test.go
+++ b/internal/features/profiles/handlers/profile_test.go
@@ -30,7 +30,7 @@ func TestCreateProfile_Success(t *testing.T) {
 		{Name: "Morning", Time: "08:00"},
 	}
 
-	mockSvc.On("CreateProfile", mock.Anything, "Test Profile", mock.Anything, "America/New_York", schedules).Return(&service.ProfileResult{
+	mockSvc.On("CreateProfile", mock.Anything, userID, "Test Profile", mock.Anything, "America/New_York", schedules).Return(&service.ProfileResult{
 		Profile: service.ProfileDTO{
 			ID:          profileID,
 			Name:        "Test Profile",
@@ -93,7 +93,7 @@ func TestCreateProfile_InvalidTimezone(t *testing.T) {
 		"sub": userID.String(),
 	}, nil)
 
-	mockSvc.On("CreateProfile", mock.Anything, "Test Profile", mock.Anything, "Invalid/Timezone", mock.Anything).Return(nil, service.ErrInvalidTimezone)
+	mockSvc.On("CreateProfile", mock.Anything, userID, "Test Profile", mock.Anything, "Invalid/Timezone", mock.Anything).Return(nil, service.ErrInvalidTimezone)
 
 	handler := handlers.CreateProfileHandler(mockSvc, mockTokenSvc)
 

--- a/internal/features/profiles/repository/profile_repository.go
+++ b/internal/features/profiles/repository/profile_repository.go
@@ -12,6 +12,7 @@ import (
 type ProfileRepository interface {
 	CreateProfile(ctx context.Context, name string, dateOfBirth sql.NullTime, timezone string) (db.Profile, error)
 	CreateProfilePermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions json.RawMessage) error
+	CreateProfileWithPermission(ctx context.Context, name string, dateOfBirth sql.NullTime, timezone string, userID uuid.UUID, permissions json.RawMessage) (db.Profile, error)
 	GetProfileByID(ctx context.Context, id uuid.UUID) (db.Profile, error)
 	ListProfilesByUser(ctx context.Context, userID uuid.UUID) ([]db.Profile, error)
 	UpdateProfile(ctx context.Context, id uuid.UUID, name string, dateOfBirth sql.NullTime, timezone string) (db.Profile, error)
@@ -20,10 +21,11 @@ type ProfileRepository interface {
 
 type profileRepository struct {
 	queries *db.Queries
+	db      *sql.DB
 }
 
-func NewProfileRepository(queries *db.Queries) ProfileRepository {
-	return &profileRepository{queries: queries}
+func NewProfileRepository(queries *db.Queries, db *sql.DB) ProfileRepository {
+	return &profileRepository{queries: queries, db: db}
 }
 
 func (r *profileRepository) CreateProfile(ctx context.Context, name string, dateOfBirth sql.NullTime, timezone string) (db.Profile, error) {
@@ -44,6 +46,43 @@ func (r *profileRepository) CreateProfilePermission(ctx context.Context, profile
 		ExpiresAt:        sql.NullTime{},
 	})
 	return err
+}
+
+func (r *profileRepository) CreateProfileWithPermission(ctx context.Context, name string, dateOfBirth sql.NullTime, timezone string, userID uuid.UUID, permissions json.RawMessage) (db.Profile, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return db.Profile{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	qtx := r.queries.WithTx(tx)
+
+	profile, err := qtx.CreateProfile(ctx, db.CreateProfileParams{
+		Name:        name,
+		DateOfBirth: dateOfBirth,
+		Timezone:    timezone,
+	})
+	if err != nil {
+		return db.Profile{}, err
+	}
+
+	_, err = qtx.CreateProfilePermission(ctx, db.CreateProfilePermissionParams{
+		ProfileID:        profile.ID,
+		SharedWithUserID: userID,
+		GrantedByUserID:  userID,
+		Permissions:      permissions,
+		Status:           "accepted",
+		ExpiresAt:        sql.NullTime{},
+	})
+	if err != nil {
+		return db.Profile{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return db.Profile{}, err
+	}
+
+	return profile, nil
 }
 
 func (r *profileRepository) GetProfileByID(ctx context.Context, id uuid.UUID) (db.Profile, error) {

--- a/internal/features/profiles/repository/profile_repository.go
+++ b/internal/features/profiles/repository/profile_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 
 	"github.com/google/uuid"
 	"github.com/shuvo-paul/medminder/internal/database/sqlc"
@@ -10,6 +11,7 @@ import (
 
 type ProfileRepository interface {
 	CreateProfile(ctx context.Context, name string, dateOfBirth sql.NullTime, timezone string) (db.Profile, error)
+	CreateProfilePermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions json.RawMessage) error
 	GetProfileByID(ctx context.Context, id uuid.UUID) (db.Profile, error)
 	ListProfilesByUser(ctx context.Context, userID uuid.UUID) ([]db.Profile, error)
 	UpdateProfile(ctx context.Context, id uuid.UUID, name string, dateOfBirth sql.NullTime, timezone string) (db.Profile, error)
@@ -30,6 +32,18 @@ func (r *profileRepository) CreateProfile(ctx context.Context, name string, date
 		DateOfBirth: dateOfBirth,
 		Timezone:    timezone,
 	})
+}
+
+func (r *profileRepository) CreateProfilePermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions json.RawMessage) error {
+	_, err := r.queries.CreateProfilePermission(ctx, db.CreateProfilePermissionParams{
+		ProfileID:        profileID,
+		SharedWithUserID: userID,
+		GrantedByUserID:  userID,
+		Permissions:      permissions,
+		Status:           "accepted",
+		ExpiresAt:        sql.NullTime{},
+	})
+	return err
 }
 
 func (r *profileRepository) GetProfileByID(ctx context.Context, id uuid.UUID) (db.Profile, error) {

--- a/internal/features/profiles/routes.go
+++ b/internal/features/profiles/routes.go
@@ -13,7 +13,7 @@ import (
 )
 
 func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc authService.TokenServiceInterface) {
-	profileRepo := repository.NewProfileRepository(queries)
+	profileRepo := repository.NewProfileRepository(queries, dbConn)
 	scheduleRepo := repository.NewDoseScheduleRepository(queries)
 	permChecker := profileService.NewPermissionChecker(queries)
 	profileSvc := profileService.NewProfileService(profileRepo, scheduleRepo, permChecker)

--- a/internal/features/profiles/routes.go
+++ b/internal/features/profiles/routes.go
@@ -15,9 +15,9 @@ import (
 func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, tokenSvc authService.TokenServiceInterface) {
 	profileRepo := repository.NewProfileRepository(queries)
 	scheduleRepo := repository.NewDoseScheduleRepository(queries)
-	profileSvc := profileService.NewProfileService(profileRepo, scheduleRepo)
-	scheduleSvc := profileService.NewDoseScheduleService(profileRepo, scheduleRepo)
 	permChecker := profileService.NewPermissionChecker(queries)
+	profileSvc := profileService.NewProfileService(profileRepo, scheduleRepo, permChecker)
+	scheduleSvc := profileService.NewDoseScheduleService(profileRepo, scheduleRepo)
 
 	readPerm := middleware.HumaRequireProfilePermission(permChecker, tokenSvc, "profile:read", "profile:owner")
 	writePerm := middleware.HumaRequireProfilePermission(permChecker, tokenSvc, "profile:write", "profile:owner")

--- a/internal/features/profiles/service/profile_service.go
+++ b/internal/features/profiles/service/profile_service.go
@@ -72,13 +72,13 @@ func (s *profileService) CreateProfile(ctx context.Context, userID uuid.UUID, na
 		dob = sql.NullTime{Time: *dateOfBirth, Valid: true}
 	}
 
-	profile, err := s.profileRepo.CreateProfile(ctx, name, dob, timezone)
+	ownerPerms, err := json.Marshal([]string{"profile:owner", "profile:admin"})
 	if err != nil {
 		return nil, err
 	}
 
-	ownerPerms, _ := json.Marshal([]string{"profile:owner", "profile:admin"})
-	if err := s.profileRepo.CreateProfilePermission(ctx, profile.ID, userID, ownerPerms); err != nil {
+	profile, err := s.profileRepo.CreateProfileWithPermission(ctx, name, dob, timezone, userID, ownerPerms)
+	if err != nil {
 		return nil, err
 	}
 
@@ -106,7 +106,10 @@ func (s *profileService) GetProfile(ctx context.Context, profileID uuid.UUID, us
 		return nil, err
 	}
 
-	isOwner, _ := s.permChecker.HasPermission(ctx, profileID, userID, "profile:owner")
+	isOwner, err := s.permChecker.HasPermission(ctx, profileID, userID, "profile:owner")
+	if err != nil {
+		return nil, err
+	}
 
 	schedules, err := s.scheduleRepo.ListDoseSchedulesByProfile(ctx, profileID)
 	if err != nil {
@@ -125,7 +128,10 @@ func (s *profileService) ListProfiles(ctx context.Context, userID uuid.UUID) ([]
 
 	var results []ProfileResult
 	for _, profile := range profiles {
-		isOwner, _ := s.permChecker.HasPermission(ctx, profile.ID, userID, "profile:owner")
+		isOwner, err := s.permChecker.HasPermission(ctx, profile.ID, userID, "profile:owner")
+		if err != nil {
+			return nil, err
+		}
 		schedules, err := s.scheduleRepo.ListDoseSchedulesByProfile(ctx, profile.ID)
 		if err != nil {
 			return nil, err
@@ -145,7 +151,10 @@ func (s *profileService) UpdateProfile(ctx context.Context, profileID uuid.UUID,
 		return nil, err
 	}
 
-	isOwner, _ := s.permChecker.HasPermission(ctx, profileID, userID, "profile:owner")
+	isOwner, err := s.permChecker.HasPermission(ctx, profileID, userID, "profile:owner")
+	if err != nil {
+		return nil, err
+	}
 
 	updatedName := profile.Name
 	if name != nil {

--- a/internal/features/profiles/service/profile_service.go
+++ b/internal/features/profiles/service/profile_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,6 +25,7 @@ type ProfileDTO struct {
 	Name        string
 	DateOfBirth *string
 	Timezone    string
+	IsOwner     bool
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	Schedules   []DoseScheduleDTO
@@ -39,7 +41,7 @@ type DoseScheduleDTO struct {
 }
 
 type ProfileService interface {
-	CreateProfile(ctx context.Context, name string, dateOfBirth *time.Time, timezone string, schedules []DoseScheduleInput) (*ProfileResult, error)
+	CreateProfile(ctx context.Context, userID uuid.UUID, name string, dateOfBirth *time.Time, timezone string, schedules []DoseScheduleInput) (*ProfileResult, error)
 	GetProfile(ctx context.Context, profileID uuid.UUID, userID uuid.UUID) (*ProfileResult, error)
 	ListProfiles(ctx context.Context, userID uuid.UUID) ([]ProfileResult, error)
 	UpdateProfile(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, name *string, dateOfBirth *time.Time, timezone *string) (*ProfileResult, error)
@@ -49,16 +51,18 @@ type ProfileService interface {
 type profileService struct {
 	profileRepo  repository.ProfileRepository
 	scheduleRepo repository.DoseScheduleRepository
+	permChecker  PermissionChecker
 }
 
-func NewProfileService(profileRepo repository.ProfileRepository, scheduleRepo repository.DoseScheduleRepository) ProfileService {
+func NewProfileService(profileRepo repository.ProfileRepository, scheduleRepo repository.DoseScheduleRepository, permChecker PermissionChecker) ProfileService {
 	return &profileService{
 		profileRepo:  profileRepo,
 		scheduleRepo: scheduleRepo,
+		permChecker:  permChecker,
 	}
 }
 
-func (s *profileService) CreateProfile(ctx context.Context, name string, dateOfBirth *time.Time, timezone string, schedules []DoseScheduleInput) (*ProfileResult, error) {
+func (s *profileService) CreateProfile(ctx context.Context, userID uuid.UUID, name string, dateOfBirth *time.Time, timezone string, schedules []DoseScheduleInput) (*ProfileResult, error) {
 	if _, err := time.LoadLocation(timezone); err != nil {
 		return nil, ErrInvalidTimezone
 	}
@@ -73,6 +77,11 @@ func (s *profileService) CreateProfile(ctx context.Context, name string, dateOfB
 		return nil, err
 	}
 
+	ownerPerms, _ := json.Marshal([]string{"profile:owner", "profile:admin"})
+	if err := s.profileRepo.CreateProfilePermission(ctx, profile.ID, userID, ownerPerms); err != nil {
+		return nil, err
+	}
+
 	for _, schedule := range schedules {
 		t, err := time.Parse("15:04", schedule.Time)
 		if err != nil {
@@ -84,7 +93,7 @@ func (s *profileService) CreateProfile(ctx context.Context, name string, dateOfB
 		}
 	}
 
-	profileResult := toProfileResult(profile, []DoseScheduleDTO{})
+	profileResult := toProfileResult(profile, []DoseScheduleDTO{}, true)
 	return &profileResult, nil
 }
 
@@ -97,12 +106,14 @@ func (s *profileService) GetProfile(ctx context.Context, profileID uuid.UUID, us
 		return nil, err
 	}
 
+	isOwner, _ := s.permChecker.HasPermission(ctx, profileID, userID, "profile:owner")
+
 	schedules, err := s.scheduleRepo.ListDoseSchedulesByProfile(ctx, profileID)
 	if err != nil {
 		return nil, err
 	}
 
-	profileResult := toProfileResult(profile, toDoseScheduleDTOs(schedules))
+	profileResult := toProfileResult(profile, toDoseScheduleDTOs(schedules), isOwner)
 	return &profileResult, nil
 }
 
@@ -114,11 +125,12 @@ func (s *profileService) ListProfiles(ctx context.Context, userID uuid.UUID) ([]
 
 	var results []ProfileResult
 	for _, profile := range profiles {
+		isOwner, _ := s.permChecker.HasPermission(ctx, profile.ID, userID, "profile:owner")
 		schedules, err := s.scheduleRepo.ListDoseSchedulesByProfile(ctx, profile.ID)
 		if err != nil {
 			return nil, err
 		}
-		results = append(results, toProfileResult(profile, toDoseScheduleDTOs(schedules)))
+		results = append(results, toProfileResult(profile, toDoseScheduleDTOs(schedules), isOwner))
 	}
 
 	return results, nil
@@ -132,6 +144,8 @@ func (s *profileService) UpdateProfile(ctx context.Context, profileID uuid.UUID,
 		}
 		return nil, err
 	}
+
+	isOwner, _ := s.permChecker.HasPermission(ctx, profileID, userID, "profile:owner")
 
 	updatedName := profile.Name
 	if name != nil {
@@ -163,7 +177,7 @@ func (s *profileService) UpdateProfile(ctx context.Context, profileID uuid.UUID,
 		return nil, err
 	}
 
-	profileResult := toProfileResult(updated, toDoseScheduleDTOs(schedules))
+	profileResult := toProfileResult(updated, toDoseScheduleDTOs(schedules), isOwner)
 	return &profileResult, nil
 }
 
@@ -183,7 +197,7 @@ func (s *profileService) DeleteProfile(ctx context.Context, profileID uuid.UUID,
 	return s.profileRepo.DeleteProfile(ctx, profileID)
 }
 
-func toProfileResult(profile db.Profile, schedules []DoseScheduleDTO) ProfileResult {
+func toProfileResult(profile db.Profile, schedules []DoseScheduleDTO, isOwner bool) ProfileResult {
 	var dob *string
 	if profile.DateOfBirth.Valid {
 		s := profile.DateOfBirth.Time.Format("2006-01-02")
@@ -196,6 +210,7 @@ func toProfileResult(profile db.Profile, schedules []DoseScheduleDTO) ProfileRes
 			Name:        profile.Name,
 			DateOfBirth: dob,
 			Timezone:    profile.Timezone,
+			IsOwner:     isOwner,
 			CreatedAt:   profile.CreatedAt,
 			UpdatedAt:   profile.UpdatedAt,
 			Schedules:   schedules,

--- a/internal/features/profiles/service/profile_service_test.go
+++ b/internal/features/profiles/service/profile_service_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -14,6 +15,20 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+type MockPermissionChecker struct {
+	mock.Mock
+}
+
+func (m *MockPermissionChecker) HasPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permission string) (bool, error) {
+	args := m.Called(ctx, profileID, userID, permission)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockPermissionChecker) HasAnyPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions []string) (bool, error) {
+	args := m.Called(ctx, profileID, userID, permissions)
+	return args.Bool(0), args.Error(1)
+}
+
 type MockProfileRepository struct {
 	mock.Mock
 }
@@ -21,6 +36,11 @@ type MockProfileRepository struct {
 func (m *MockProfileRepository) CreateProfile(ctx context.Context, name string, dateOfBirth sql.NullTime, timezone string) (db.Profile, error) {
 	args := m.Called(ctx, name, dateOfBirth, timezone)
 	return args.Get(0).(db.Profile), args.Error(1)
+}
+
+func (m *MockProfileRepository) CreateProfilePermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permissions json.RawMessage) error {
+	args := m.Called(ctx, profileID, userID, permissions)
+	return args.Error(0)
 }
 
 func (m *MockProfileRepository) GetProfileByID(ctx context.Context, id uuid.UUID) (db.Profile, error) {
@@ -80,8 +100,9 @@ func (m *MockDoseScheduleRepository) DeleteDoseSchedulesByProfile(ctx context.Co
 func TestProfileService_Create(t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func(*MockProfileRepository, *MockDoseScheduleRepository)
+		setup func(*MockProfileRepository, *MockDoseScheduleRepository, *MockPermissionChecker)
 		input struct {
+			userID      uuid.UUID
 			name        string
 			dateOfBirth *time.Time
 			timezone    string
@@ -91,7 +112,8 @@ func TestProfileService_Create(t *testing.T) {
 	}{
 		{
 			name: "CreateProfile_Success",
-			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository) {
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
+				userID := uuid.UUID{1}
 				profileID := uuid.New()
 				now := time.Now()
 				profileRepo.On("CreateProfile", mock.Anything, "Test Profile", mock.Anything, "UTC").
@@ -102,6 +124,8 @@ func TestProfileService_Create(t *testing.T) {
 						CreatedAt: now,
 						UpdatedAt: now,
 					}, nil)
+				profileRepo.On("CreateProfilePermission", mock.Anything, profileID, userID, mock.Anything).
+					Return(nil)
 				scheduleRepo.On("CreateDoseSchedule", mock.Anything, profileID, "Morning", mock.Anything).
 					Return(db.DoseSchedule{
 						ID:        uuid.New(),
@@ -113,11 +137,13 @@ func TestProfileService_Create(t *testing.T) {
 					}, nil)
 			},
 			input: struct {
+				userID      uuid.UUID
 				name        string
 				dateOfBirth *time.Time
 				timezone    string
 				schedules   []service.DoseScheduleInput
 			}{
+				userID:      uuid.UUID{1},
 				name:        "Test Profile",
 				dateOfBirth: nil,
 				timezone:    "UTC",
@@ -130,18 +156,21 @@ func TestProfileService_Create(t *testing.T) {
 				assert.NotNil(t, result)
 				assert.Equal(t, "Test Profile", result.Profile.Name)
 				assert.Equal(t, "UTC", result.Profile.Timezone)
+				assert.True(t, result.Profile.IsOwner)
 			},
 		},
 		{
 			name: "CreateProfile_InvalidTimezone",
-			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository) {
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
 			},
 			input: struct {
+				userID      uuid.UUID
 				name        string
 				dateOfBirth *time.Time
 				timezone    string
 				schedules   []service.DoseScheduleInput
 			}{
+				userID:      uuid.UUID{1},
 				name:        "Test Profile",
 				dateOfBirth: nil,
 				timezone:    "Invalid/Timezone",
@@ -158,9 +187,10 @@ func TestProfileService_Create(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			profileRepo := new(MockProfileRepository)
 			scheduleRepo := new(MockDoseScheduleRepository)
-			svc := service.NewProfileService(profileRepo, scheduleRepo)
-			tt.setup(profileRepo, scheduleRepo)
-			result, err := svc.CreateProfile(context.Background(), tt.input.name, tt.input.dateOfBirth, tt.input.timezone, tt.input.schedules)
+			permChecker := new(MockPermissionChecker)
+			svc := service.NewProfileService(profileRepo, scheduleRepo, permChecker)
+			tt.setup(profileRepo, scheduleRepo, permChecker)
+			result, err := svc.CreateProfile(context.Background(), tt.input.userID, tt.input.name, tt.input.dateOfBirth, tt.input.timezone, tt.input.schedules)
 			tt.expect(t, result, err)
 		})
 	}
@@ -169,7 +199,7 @@ func TestProfileService_Create(t *testing.T) {
 func TestProfileService_Get(t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func(*MockProfileRepository, *MockDoseScheduleRepository)
+		setup func(*MockProfileRepository, *MockDoseScheduleRepository, *MockPermissionChecker)
 		input struct {
 			profileID uuid.UUID
 			userID    uuid.UUID
@@ -178,7 +208,7 @@ func TestProfileService_Get(t *testing.T) {
 	}{
 		{
 			name: "GetProfile_Success",
-			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository) {
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
 				now := time.Now()
 				profileRepo.On("GetProfileByID", mock.Anything, mock.Anything).
 					Return(db.Profile{
@@ -188,6 +218,8 @@ func TestProfileService_Get(t *testing.T) {
 						CreatedAt: now,
 						UpdatedAt: now,
 					}, nil)
+				permChecker.On("HasPermission", mock.Anything, mock.Anything, mock.Anything, "profile:owner").
+					Return(false, nil)
 				scheduleRepo.On("ListDoseSchedulesByProfile", mock.Anything, mock.Anything).
 					Return([]db.DoseSchedule{}, nil)
 			},
@@ -201,11 +233,12 @@ func TestProfileService_Get(t *testing.T) {
 			expect: func(t *testing.T, result *service.ProfileResult, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
+				assert.False(t, result.Profile.IsOwner)
 			},
 		},
 		{
 			name: "GetProfile_NotFound",
-			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository) {
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
 				profileRepo.On("GetProfileByID", mock.Anything, mock.Anything).
 					Return(db.Profile{}, sql.ErrNoRows)
 			},
@@ -227,8 +260,9 @@ func TestProfileService_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			profileRepo := new(MockProfileRepository)
 			scheduleRepo := new(MockDoseScheduleRepository)
-			svc := service.NewProfileService(profileRepo, scheduleRepo)
-			tt.setup(profileRepo, scheduleRepo)
+			permChecker := new(MockPermissionChecker)
+			svc := service.NewProfileService(profileRepo, scheduleRepo, permChecker)
+			tt.setup(profileRepo, scheduleRepo, permChecker)
 			result, err := svc.GetProfile(context.Background(), tt.input.profileID, tt.input.userID)
 			tt.expect(t, result, err)
 		})
@@ -238,13 +272,13 @@ func TestProfileService_Get(t *testing.T) {
 func TestProfileService_List(t *testing.T) {
 	tests := []struct {
 		name   string
-		setup  func(*MockProfileRepository, *MockDoseScheduleRepository)
+		setup  func(*MockProfileRepository, *MockDoseScheduleRepository, *MockPermissionChecker)
 		input  uuid.UUID
 		expect func(*testing.T, []service.ProfileResult, error)
 	}{
 		{
 			name: "ListProfiles_Success",
-			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository) {
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
 				now := time.Now()
 				profileRepo.On("ListProfilesByUser", mock.Anything, mock.Anything).
 					Return([]db.Profile{
@@ -263,6 +297,8 @@ func TestProfileService_List(t *testing.T) {
 							UpdatedAt: now,
 						},
 					}, nil)
+				permChecker.On("HasPermission", mock.Anything, mock.Anything, mock.Anything, "profile:owner").
+					Return(false, nil).Maybe()
 				scheduleRepo.On("ListDoseSchedulesByProfile", mock.Anything, mock.Anything).
 					Return([]db.DoseSchedule{}, nil).Maybe()
 			},
@@ -278,8 +314,9 @@ func TestProfileService_List(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			profileRepo := new(MockProfileRepository)
 			scheduleRepo := new(MockDoseScheduleRepository)
-			svc := service.NewProfileService(profileRepo, scheduleRepo)
-			tt.setup(profileRepo, scheduleRepo)
+			permChecker := new(MockPermissionChecker)
+			svc := service.NewProfileService(profileRepo, scheduleRepo, permChecker)
+			tt.setup(profileRepo, scheduleRepo, permChecker)
 			result, err := svc.ListProfiles(context.Background(), tt.input)
 			tt.expect(t, result, err)
 		})
@@ -289,7 +326,7 @@ func TestProfileService_List(t *testing.T) {
 func TestProfileService_Update(t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func(*MockProfileRepository, *MockDoseScheduleRepository)
+		setup func(*MockProfileRepository, *MockDoseScheduleRepository, *MockPermissionChecker)
 		input struct {
 			profileID uuid.UUID
 			userID    uuid.UUID
@@ -300,7 +337,7 @@ func TestProfileService_Update(t *testing.T) {
 	}{
 		{
 			name: "UpdateProfile_Success",
-			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository) {
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
 				now := time.Now()
 				profileID := uuid.New()
 				profileRepo.On("GetProfileByID", mock.Anything, mock.Anything).
@@ -311,6 +348,8 @@ func TestProfileService_Update(t *testing.T) {
 						CreatedAt: now,
 						UpdatedAt: now,
 					}, nil)
+				permChecker.On("HasPermission", mock.Anything, mock.Anything, mock.Anything, "profile:owner").
+					Return(false, nil)
 				newName := "New Name"
 				profileRepo.On("UpdateProfile", mock.Anything, mock.Anything, newName, mock.Anything, "UTC").
 					Return(db.Profile{
@@ -345,8 +384,9 @@ func TestProfileService_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			profileRepo := new(MockProfileRepository)
 			scheduleRepo := new(MockDoseScheduleRepository)
-			svc := service.NewProfileService(profileRepo, scheduleRepo)
-			tt.setup(profileRepo, scheduleRepo)
+			permChecker := new(MockPermissionChecker)
+			svc := service.NewProfileService(profileRepo, scheduleRepo, permChecker)
+			tt.setup(profileRepo, scheduleRepo, permChecker)
 			result, err := svc.UpdateProfile(context.Background(), tt.input.profileID, tt.input.userID, tt.input.name, nil, tt.input.timezone)
 			tt.expect(t, result, err)
 		})
@@ -356,7 +396,7 @@ func TestProfileService_Update(t *testing.T) {
 func TestProfileService_Delete(t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func(*MockProfileRepository, *MockDoseScheduleRepository)
+		setup func(*MockProfileRepository, *MockDoseScheduleRepository, *MockPermissionChecker)
 		input struct {
 			profileID uuid.UUID
 			userID    uuid.UUID
@@ -365,7 +405,7 @@ func TestProfileService_Delete(t *testing.T) {
 	}{
 		{
 			name: "DeleteProfile_Success",
-			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository) {
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
 				profileRepo.On("GetProfileByID", mock.Anything, mock.Anything).
 					Return(db.Profile{
 						ID:        uuid.New(),
@@ -394,8 +434,9 @@ func TestProfileService_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			profileRepo := new(MockProfileRepository)
 			scheduleRepo := new(MockDoseScheduleRepository)
-			svc := service.NewProfileService(profileRepo, scheduleRepo)
-			tt.setup(profileRepo, scheduleRepo)
+			permChecker := new(MockPermissionChecker)
+			svc := service.NewProfileService(profileRepo, scheduleRepo, permChecker)
+			tt.setup(profileRepo, scheduleRepo, permChecker)
 			err := svc.DeleteProfile(context.Background(), tt.input.profileID, tt.input.userID)
 			tt.expect(t, err)
 		})

--- a/internal/features/profiles/service/profile_service_test.go
+++ b/internal/features/profiles/service/profile_service_test.go
@@ -43,6 +43,11 @@ func (m *MockProfileRepository) CreateProfilePermission(ctx context.Context, pro
 	return args.Error(0)
 }
 
+func (m *MockProfileRepository) CreateProfileWithPermission(ctx context.Context, name string, dateOfBirth sql.NullTime, timezone string, userID uuid.UUID, permissions json.RawMessage) (db.Profile, error) {
+	args := m.Called(ctx, name, dateOfBirth, timezone, userID, permissions)
+	return args.Get(0).(db.Profile), args.Error(1)
+}
+
 func (m *MockProfileRepository) GetProfileByID(ctx context.Context, id uuid.UUID) (db.Profile, error) {
 	args := m.Called(ctx, id)
 	return args.Get(0).(db.Profile), args.Error(1)
@@ -116,7 +121,7 @@ func TestProfileService_Create(t *testing.T) {
 				userID := uuid.UUID{1}
 				profileID := uuid.New()
 				now := time.Now()
-				profileRepo.On("CreateProfile", mock.Anything, "Test Profile", mock.Anything, "UTC").
+				profileRepo.On("CreateProfileWithPermission", mock.Anything, "Test Profile", mock.Anything, "UTC", userID, mock.Anything).
 					Return(db.Profile{
 						ID:        profileID,
 						Name:      "Test Profile",
@@ -124,8 +129,6 @@ func TestProfileService_Create(t *testing.T) {
 						CreatedAt: now,
 						UpdatedAt: now,
 					}, nil)
-				profileRepo.On("CreateProfilePermission", mock.Anything, profileID, userID, mock.Anything).
-					Return(nil)
 				scheduleRepo.On("CreateDoseSchedule", mock.Anything, profileID, "Morning", mock.Anything).
 					Return(db.DoseSchedule{
 						ID:        uuid.New(),
@@ -179,6 +182,31 @@ func TestProfileService_Create(t *testing.T) {
 			expect: func(t *testing.T, result *service.ProfileResult, err error) {
 				assert.Error(t, err)
 				assert.True(t, errors.Is(err, service.ErrInvalidTimezone))
+			},
+		},
+		{
+			name: "CreateProfile_PermissionError",
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
+				userID := uuid.UUID{1}
+				profileRepo.On("CreateProfileWithPermission", mock.Anything, "Test Profile", mock.Anything, "UTC", userID, mock.Anything).
+					Return(db.Profile{}, errors.New("db error"))
+			},
+			input: struct {
+				userID      uuid.UUID
+				name        string
+				dateOfBirth *time.Time
+				timezone    string
+				schedules   []service.DoseScheduleInput
+			}{
+				userID:      uuid.UUID{1},
+				name:        "Test Profile",
+				dateOfBirth: nil,
+				timezone:    "UTC",
+				schedules:   nil,
+			},
+			expect: func(t *testing.T, result *service.ProfileResult, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "db error")
 			},
 		},
 	}
@@ -254,6 +282,32 @@ func TestProfileService_Get(t *testing.T) {
 				assert.True(t, errors.Is(err, service.ErrProfileNotFound))
 			},
 		},
+		{
+			name: "GetProfile_HasPermissionError",
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
+				profileRepo.On("GetProfileByID", mock.Anything, mock.Anything).
+					Return(db.Profile{
+						ID:        uuid.New(),
+						Name:      "Test Profile",
+						Timezone:  "UTC",
+						CreatedAt: time.Now(),
+						UpdatedAt: time.Now(),
+					}, nil)
+				permChecker.On("HasPermission", mock.Anything, mock.Anything, mock.Anything, "profile:owner").
+					Return(false, errors.New("permission db error"))
+			},
+			input: struct {
+				profileID uuid.UUID
+				userID    uuid.UUID
+			}{
+				profileID: uuid.New(),
+				userID:    uuid.UUID{1},
+			},
+			expect: func(t *testing.T, result *service.ProfileResult, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "permission db error")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -306,6 +360,29 @@ func TestProfileService_List(t *testing.T) {
 			expect: func(t *testing.T, result []service.ProfileResult, err error) {
 				assert.NoError(t, err)
 				assert.Len(t, result, 2)
+			},
+		},
+		{
+			name: "ListProfiles_HasPermissionError",
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
+				now := time.Now()
+				profileRepo.On("ListProfilesByUser", mock.Anything, mock.Anything).
+					Return([]db.Profile{
+						{
+							ID:        uuid.New(),
+							Name:      "Profile 1",
+							Timezone:  "UTC",
+							CreatedAt: now,
+							UpdatedAt: now,
+						},
+					}, nil)
+				permChecker.On("HasPermission", mock.Anything, mock.Anything, mock.Anything, "profile:owner").
+					Return(false, errors.New("permission db error"))
+			},
+			input: uuid.New(),
+			expect: func(t *testing.T, result []service.ProfileResult, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "permission db error")
 			},
 		},
 	}
@@ -376,6 +453,37 @@ func TestProfileService_Update(t *testing.T) {
 			expect: func(t *testing.T, result *service.ProfileResult, err error) {
 				assert.NoError(t, err)
 				assert.NotNil(t, result)
+			},
+		},
+		{
+			name: "UpdateProfile_HasPermissionError",
+			setup: func(profileRepo *MockProfileRepository, scheduleRepo *MockDoseScheduleRepository, permChecker *MockPermissionChecker) {
+				now := time.Now()
+				profileRepo.On("GetProfileByID", mock.Anything, mock.Anything).
+					Return(db.Profile{
+						ID:        uuid.New(),
+						Name:      "Old Name",
+						Timezone:  "UTC",
+						CreatedAt: now,
+						UpdatedAt: now,
+					}, nil)
+				permChecker.On("HasPermission", mock.Anything, mock.Anything, mock.Anything, "profile:owner").
+					Return(false, errors.New("permission db error"))
+			},
+			input: struct {
+				profileID uuid.UUID
+				userID    uuid.UUID
+				name      *string
+				timezone  *string
+			}{
+				profileID: uuid.New(),
+				userID:    uuid.UUID{1},
+				name:      func() *string { s := "New Name"; return &s }(),
+				timezone:  nil,
+			},
+			expect: func(t *testing.T, result *service.ProfileResult, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "permission db error")
 			},
 		},
 	}


### PR DESCRIPTION
Replaces the deprecated `owner_user_id` column with permission-based access control for profile CRUD:

- Add `IsOwner` field to DTOs
- `CreateProfile` inserts `profile:owner` + `profile:admin` permission rows
- `GetProfile`/ListProfiles`/`UpdateProfile` compute `IsOwner` via `PermissionChecker`
- `ListProfilesByUser` SQL query filters by `status = 'accepted'`
