### PR TITLE
Account deletion cascade for shared profiles

### DIFF
--- a/internal/database/sqlc/queries/users.sql
+++ b/internal/database/sqlc/queries/users.sql
@@ -27,3 +27,6 @@ UPDATE users SET email_verified = true, updated_at = NOW() WHERE id = $1;
 
 -- name: UpdateUserEmail :exec
 UPDATE users SET email = $2, email_verified = true, updated_at = NOW() WHERE id = $1;
+
+-- name: DeleteUser :exec
+DELETE FROM users WHERE id = $1;

--- a/internal/database/sqlc/users.sql.go
+++ b/internal/database/sqlc/users.sql.go
@@ -57,6 +57,15 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateU
 	return i, err
 }
 
+const deleteUser = `-- name: DeleteUser :exec
+DELETE FROM users WHERE id = $1
+`
+
+func (q *Queries) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, deleteUser, id)
+	return err
+}
+
 const getUserByEmail = `-- name: GetUserByEmail :one
 SELECT id, email, display_name, password_hash, email_verified, created_at, updated_at
 FROM users

--- a/internal/features/auth/dto/auth.go
+++ b/internal/features/auth/dto/auth.go
@@ -63,3 +63,16 @@ type ChangePasswordOutput struct {
 		Message string `json:"message"`
 	}
 }
+
+type DeleteAccountInput struct {
+	Authorization string `header:"Authorization"`
+	Body          struct {
+		Password string `json:"password" minLength:"1"`
+	}
+}
+
+type DeleteAccountOutput struct {
+	Body struct {
+		Message string `json:"message"`
+	}
+}

--- a/internal/features/auth/handlers/account.go
+++ b/internal/features/auth/handlers/account.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
+	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+	profilesvc "github.com/shuvo-paul/medminder/internal/features/profiles/service"
+)
+
+func DeleteAccountHandler(authSvc service.AuthService, profileSvc profilesvc.ProfileService, tokenSvc service.TokenServiceInterface) func(context.Context, *dto.DeleteAccountInput) (*dto.DeleteAccountOutput, error) {
+	return func(ctx context.Context, input *dto.DeleteAccountInput) (*dto.DeleteAccountOutput, error) {
+		userID, err := ExtractUserIDFromAuth(input.Authorization, tokenSvc)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := authSvc.VerifyPassword(ctx, userID, input.Body.Password); err != nil {
+			if errors.Is(err, service.ErrWrongPassword) {
+				return nil, huma.Error403Forbidden("current password is incorrect", err)
+			}
+			if errors.Is(err, service.ErrUserNotFound) {
+				return nil, huma.Error404NotFound("user not found", err)
+			}
+			return nil, huma.Error500InternalServerError("failed to verify password", err)
+		}
+
+		if err := profileSvc.HandleAccountDeletion(ctx, userID); err != nil {
+			return nil, huma.Error500InternalServerError("failed to handle profile cleanup", err)
+		}
+
+		if err := authSvc.DeleteAccount(ctx, userID); err != nil {
+			return nil, huma.Error500InternalServerError("failed to delete account", err)
+		}
+
+		return &dto.DeleteAccountOutput{
+			Body: struct {
+				Message string `json:"message"`
+			}{Message: "account deleted successfully"},
+		}, nil
+	}
+}

--- a/internal/features/auth/handlers/account_test.go
+++ b/internal/features/auth/handlers/account_test.go
@@ -1,0 +1,197 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/shuvo-paul/medminder/internal/features/auth/dto"
+	"github.com/shuvo-paul/medminder/internal/features/auth/handlers"
+	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDeleteAccount_Successful(t *testing.T) {
+	mockAuthSvc := new(MockAuthService)
+	mockProfileSvc := new(MockProfileService)
+	mockTokenSvc := new(MockTokenService)
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+	mockAuthSvc.On("VerifyPassword", mock.Anything, userID, "Password123").Return(nil)
+	mockProfileSvc.On("HandleAccountDeletion", mock.Anything, userID).Return(nil)
+	mockAuthSvc.On("DeleteAccount", mock.Anything, userID).Return(nil)
+
+	handler := handlers.DeleteAccountHandler(mockAuthSvc, mockProfileSvc, mockTokenSvc)
+
+	input := &dto.DeleteAccountInput{
+		Authorization: "Bearer " + token,
+		Body: struct {
+			Password string `json:"password" minLength:"1"`
+		}{
+			Password: "Password123",
+		},
+	}
+	_, err := handler(context.Background(), input)
+
+	assert.NoError(t, err)
+	mockAuthSvc.AssertExpectations(t)
+	mockProfileSvc.AssertExpectations(t)
+}
+
+func TestDeleteAccount_InvalidHeader(t *testing.T) {
+	mockAuthSvc := new(MockAuthService)
+	mockProfileSvc := new(MockProfileService)
+	mockTokenSvc := new(MockTokenService)
+
+	handler := handlers.DeleteAccountHandler(mockAuthSvc, mockProfileSvc, mockTokenSvc)
+
+	input := &dto.DeleteAccountInput{
+		Authorization: "Invalid",
+		Body: struct {
+			Password string `json:"password" minLength:"1"`
+		}{
+			Password: "Password123",
+		},
+	}
+	_, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid authorization header")
+}
+
+func TestDeleteAccount_WrongPassword(t *testing.T) {
+	mockAuthSvc := new(MockAuthService)
+	mockProfileSvc := new(MockProfileService)
+	mockTokenSvc := new(MockTokenService)
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+	mockAuthSvc.On("VerifyPassword", mock.Anything, userID, "wrong-password").Return(service.ErrWrongPassword)
+
+	handler := handlers.DeleteAccountHandler(mockAuthSvc, mockProfileSvc, mockTokenSvc)
+
+	input := &dto.DeleteAccountInput{
+		Authorization: "Bearer " + token,
+		Body: struct {
+			Password string `json:"password" minLength:"1"`
+		}{
+			Password: "wrong-password",
+		},
+	}
+	_, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "current password is incorrect")
+}
+
+func TestDeleteAccount_UserNotFound(t *testing.T) {
+	mockAuthSvc := new(MockAuthService)
+	mockProfileSvc := new(MockProfileService)
+	mockTokenSvc := new(MockTokenService)
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+	mockAuthSvc.On("VerifyPassword", mock.Anything, userID, "Password123").Return(service.ErrUserNotFound)
+
+	handler := handlers.DeleteAccountHandler(mockAuthSvc, mockProfileSvc, mockTokenSvc)
+
+	input := &dto.DeleteAccountInput{
+		Authorization: "Bearer " + token,
+		Body: struct {
+			Password string `json:"password" minLength:"1"`
+		}{
+			Password: "Password123",
+		},
+	}
+	_, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "user not found")
+}
+
+func TestDeleteAccount_ProfileServiceError(t *testing.T) {
+	mockAuthSvc := new(MockAuthService)
+	mockProfileSvc := new(MockProfileService)
+	mockTokenSvc := new(MockTokenService)
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+	mockAuthSvc.On("VerifyPassword", mock.Anything, userID, "Password123").Return(nil)
+	mockProfileSvc.On("HandleAccountDeletion", mock.Anything, userID).Return(assert.AnError)
+
+	handler := handlers.DeleteAccountHandler(mockAuthSvc, mockProfileSvc, mockTokenSvc)
+
+	input := &dto.DeleteAccountInput{
+		Authorization: "Bearer " + token,
+		Body: struct {
+			Password string `json:"password" minLength:"1"`
+		}{
+			Password: "Password123",
+		},
+	}
+	_, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to handle profile cleanup")
+}
+
+func TestDeleteAccount_DeleteAccountError(t *testing.T) {
+	mockAuthSvc := new(MockAuthService)
+	mockProfileSvc := new(MockProfileService)
+	mockTokenSvc := new(MockTokenService)
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(time.Hour))
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(jwt.MapClaims{"sub": userID.String()}, nil)
+	mockAuthSvc.On("VerifyPassword", mock.Anything, userID, "Password123").Return(nil)
+	mockProfileSvc.On("HandleAccountDeletion", mock.Anything, userID).Return(nil)
+	mockAuthSvc.On("DeleteAccount", mock.Anything, userID).Return(assert.AnError)
+
+	handler := handlers.DeleteAccountHandler(mockAuthSvc, mockProfileSvc, mockTokenSvc)
+
+	input := &dto.DeleteAccountInput{
+		Authorization: "Bearer " + token,
+		Body: struct {
+			Password string `json:"password" minLength:"1"`
+		}{
+			Password: "Password123",
+		},
+	}
+	_, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete account")
+}
+
+func TestDeleteAccount_ExpiredToken(t *testing.T) {
+	mockAuthSvc := new(MockAuthService)
+	mockProfileSvc := new(MockProfileService)
+	mockTokenSvc := new(MockTokenService)
+	userID := uuid.New()
+	token := makeAccessToken(userID, "test@example.com", time.Now().Add(-time.Hour))
+
+	mockTokenSvc.On("ValidateAccessToken", token).Return(nil, service.ErrTokenExpired)
+
+	handler := handlers.DeleteAccountHandler(mockAuthSvc, mockProfileSvc, mockTokenSvc)
+
+	input := &dto.DeleteAccountInput{
+		Authorization: "Bearer " + token,
+		Body: struct {
+			Password string `json:"password" minLength:"1"`
+		}{
+			Password: "Password123",
+		},
+	}
+	_, err := handler(context.Background(), input)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid or expired access token")
+}

--- a/internal/features/auth/handlers/mocks_test.go
+++ b/internal/features/auth/handlers/mocks_test.go
@@ -9,6 +9,7 @@ import (
 	db "github.com/shuvo-paul/medminder/internal/database/sqlc"
 	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+	profilesvc "github.com/shuvo-paul/medminder/internal/features/profiles/service"
 	"github.com/shuvo-paul/medminder/pkg/oauth"
 	"github.com/stretchr/testify/mock"
 )
@@ -45,6 +46,16 @@ func (m *MockAuthService) SetPassword(ctx context.Context, userID uuid.UUID, pas
 
 func (m *MockAuthService) ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error {
 	args := m.Called(ctx, userID, currentPassword, newPassword)
+	return args.Error(0)
+}
+
+func (m *MockAuthService) VerifyPassword(ctx context.Context, userID uuid.UUID, password string) error {
+	args := m.Called(ctx, userID, password)
+	return args.Error(0)
+}
+
+func (m *MockAuthService) DeleteAccount(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
 	return args.Error(0)
 }
 
@@ -251,6 +262,11 @@ func (m *MockUserRepository) UpdateUserEmail(ctx context.Context, id uuid.UUID, 
 	return args.Error(0)
 }
 
+func (m *MockUserRepository) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 // MockAuditRepository is a mock for the audit log repository.
 type MockEmailChangeService struct {
 	mock.Mock
@@ -285,5 +301,51 @@ type MockAuditRepository struct {
 
 func (m *MockAuditRepository) LogEvent(ctx context.Context, eventType string, userID uuid.NullUUID, ipAddress, userAgent string, metadata map[string]string) error {
 	args := m.Called(ctx, eventType, userID, ipAddress, userAgent, metadata)
+	return args.Error(0)
+}
+
+type MockProfileService struct {
+	mock.Mock
+}
+
+func (m *MockProfileService) CreateProfile(ctx context.Context, userID uuid.UUID, name string, dateOfBirth *time.Time, timezone string, schedules []profilesvc.DoseScheduleInput) (*profilesvc.ProfileResult, error) {
+	args := m.Called(ctx, userID, name, dateOfBirth, timezone, schedules)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*profilesvc.ProfileResult), args.Error(1)
+}
+
+func (m *MockProfileService) GetProfile(ctx context.Context, profileID uuid.UUID, userID uuid.UUID) (*profilesvc.ProfileResult, error) {
+	args := m.Called(ctx, profileID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*profilesvc.ProfileResult), args.Error(1)
+}
+
+func (m *MockProfileService) ListProfiles(ctx context.Context, userID uuid.UUID) ([]profilesvc.ProfileResult, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]profilesvc.ProfileResult), args.Error(1)
+}
+
+func (m *MockProfileService) UpdateProfile(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, name *string, dateOfBirth *time.Time, timezone *string) (*profilesvc.ProfileResult, error) {
+	args := m.Called(ctx, profileID, userID, name, dateOfBirth, timezone)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*profilesvc.ProfileResult), args.Error(1)
+}
+
+func (m *MockProfileService) DeleteProfile(ctx context.Context, profileID uuid.UUID, userID uuid.UUID) error {
+	args := m.Called(ctx, profileID, userID)
+	return args.Error(0)
+}
+
+func (m *MockProfileService) HandleAccountDeletion(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
 	return args.Error(0)
 }

--- a/internal/features/auth/repository/user_repository.go
+++ b/internal/features/auth/repository/user_repository.go
@@ -15,6 +15,7 @@ type UserRepository interface {
 	UpdatePassword(ctx context.Context, id, passwordHash string) error
 	VerifyEmail(ctx context.Context, id uuid.UUID) error
 	UpdateUserEmail(ctx context.Context, id uuid.UUID, email string) error
+	DeleteUser(ctx context.Context, id uuid.UUID) error
 }
 
 type userRepository struct {
@@ -58,4 +59,8 @@ func (r *userRepository) UpdateUserEmail(ctx context.Context, id uuid.UUID, emai
 		ID:    id,
 		Email: email,
 	})
+}
+
+func (r *userRepository) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	return r.queries.DeleteUser(ctx, id)
 }

--- a/internal/features/auth/routes.go
+++ b/internal/features/auth/routes.go
@@ -12,9 +12,10 @@ import (
 	"github.com/shuvo-paul/medminder/internal/features/auth/handlers"
 	"github.com/shuvo-paul/medminder/internal/features/auth/repository"
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
+	profileService "github.com/shuvo-paul/medminder/internal/features/profiles/service"
 )
 
-func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, auditRepository auditRepo.AuditRepository, jwtSecret string, emailClient email.EmailClient, frontendURL string) {
+func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, auditRepository auditRepo.AuditRepository, jwtSecret string, emailClient email.EmailClient, frontendURL string, profileSvc profileService.ProfileService) {
 	// Repos (used to construct services)
 	userRepo := repository.NewUserRepository(queries)
 	tokenRepo := repository.NewRefreshTokenRepository(queries)
@@ -162,4 +163,16 @@ func RegisterRoutes(api huma.API, dbConn *sql.DB, queries *db.Queries, auditRepo
 			{"bearer": {}},
 		},
 	}, handlers.ChangePasswordHandler(authSvc, tokenSvc))
+
+	// Delete account (authenticated) — requires password confirmation
+	huma.Register(api, huma.Operation{
+		OperationID: "delete-account",
+		Method:      http.MethodDelete,
+		Path:        "/api/auth/account",
+		Summary:     "Delete the authenticated user's account",
+		Tags:        []string{"auth"},
+		Security: []map[string][]string{
+			{"bearer": {}},
+		},
+	}, handlers.DeleteAccountHandler(authSvc, profileSvc, tokenSvc))
 }

--- a/internal/features/auth/service/auth_service.go
+++ b/internal/features/auth/service/auth_service.go
@@ -39,6 +39,8 @@ type AuthService interface {
 	Logout(ctx context.Context, userID uuid.UUID) error
 	SetPassword(ctx context.Context, userID uuid.UUID, password string) error
 	ChangePassword(ctx context.Context, userID uuid.UUID, currentPassword, newPassword string) error
+	VerifyPassword(ctx context.Context, userID uuid.UUID, password string) error
+	DeleteAccount(ctx context.Context, userID uuid.UUID) error
 }
 
 type authService struct {
@@ -182,6 +184,36 @@ func (s *authService) ChangePassword(ctx context.Context, userID uuid.UUID, curr
 
 	if err := s.userRepo.UpdatePassword(ctx, userID.String(), string(hashedPassword)); err != nil {
 		return fmt.Errorf("updating password: %w", err)
+	}
+
+	return nil
+}
+
+func (s *authService) VerifyPassword(ctx context.Context, userID uuid.UUID, password string) error {
+	user, err := s.userRepo.GetUserByID(ctx, userID.String())
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrUserNotFound
+		}
+		return fmt.Errorf("getting user: %w", err)
+	}
+
+	if user.PasswordHash.Valid && user.PasswordHash.String != "" {
+		if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash.String), []byte(password)); err != nil {
+			return ErrWrongPassword
+		}
+	}
+
+	return nil
+}
+
+func (s *authService) DeleteAccount(ctx context.Context, userID uuid.UUID) error {
+	if err := s.tokenRepo.DeleteUserRefreshTokens(ctx, userID); err != nil {
+		return fmt.Errorf("deleting refresh tokens: %w", err)
+	}
+
+	if err := s.userRepo.DeleteUser(ctx, userID); err != nil {
+		return fmt.Errorf("deleting user: %w", err)
 	}
 
 	return nil

--- a/internal/features/auth/service/auth_service_test.go
+++ b/internal/features/auth/service/auth_service_test.go
@@ -54,6 +54,11 @@ func (m *MockUserRepository) UpdateUserEmail(ctx context.Context, id uuid.UUID, 
 	return args.Error(0)
 }
 
+func (m *MockUserRepository) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 // MockRefreshTokenRepository mocks repository.RefreshTokenRepository
 type MockRefreshTokenRepository struct {
 	mock.Mock

--- a/internal/features/auth/service/oauth_service_test.go
+++ b/internal/features/auth/service/oauth_service_test.go
@@ -107,6 +107,11 @@ func (m *MockOAuthUserRepository) UpdateUserEmail(ctx context.Context, id uuid.U
 	return args.Error(0)
 }
 
+func (m *MockOAuthUserRepository) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 // MockAuditRepository is a mock for the audit log repository.
 type MockAuditRepository struct {
 	mock.Mock

--- a/internal/features/auth/service/password_reset_service_test.go
+++ b/internal/features/auth/service/password_reset_service_test.go
@@ -23,6 +23,7 @@ type MockPRUserRepository struct {
 	CreateUserFn      func(ctx context.Context, email, displayName, passwordHash string, emailVerified bool) (db.CreateUserRow, error)
 	VerifyEmailFn     func(ctx context.Context, id uuid.UUID) error
 	UpdateUserEmailFn func(ctx context.Context, id uuid.UUID, email string) error
+	DeleteUserFn      func(ctx context.Context, id uuid.UUID) error
 }
 
 func (m *MockPRUserRepository) CreateUser(ctx context.Context, email, displayName, passwordHash string, emailVerified bool) (db.CreateUserRow, error) {
@@ -63,6 +64,13 @@ func (m *MockPRUserRepository) VerifyEmail(ctx context.Context, id uuid.UUID) er
 func (m *MockPRUserRepository) UpdateUserEmail(ctx context.Context, id uuid.UUID, email string) error {
 	if m.UpdateUserEmailFn != nil {
 		return m.UpdateUserEmailFn(ctx, id, email)
+	}
+	return nil
+}
+
+func (m *MockPRUserRepository) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	if m.DeleteUserFn != nil {
+		return m.DeleteUserFn(ctx, id)
 	}
 	return nil
 }

--- a/internal/features/profiles/handlers/mocks_test.go
+++ b/internal/features/profiles/handlers/mocks_test.go
@@ -51,6 +51,11 @@ func (m *MockProfileService) DeleteProfile(ctx context.Context, profileID uuid.U
 	return args.Error(0)
 }
 
+func (m *MockProfileService) HandleAccountDeletion(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
+	return args.Error(0)
+}
+
 type MockDoseScheduleService struct {
 	mock.Mock
 }

--- a/internal/features/profiles/repository/profile_repository.go
+++ b/internal/features/profiles/repository/profile_repository.go
@@ -20,7 +20,9 @@ type ProfileRepository interface {
 	DeleteProfile(ctx context.Context, id uuid.UUID) error
 	GetProfilePermissionByID(ctx context.Context, id uuid.UUID) (db.ProfilePermission, error)
 	GetProfilePermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID) (db.ProfilePermission, error)
+	ListProfilePermissionsByProfile(ctx context.Context, profileID uuid.UUID) ([]db.ProfilePermission, error)
 	ListProfilePermissionsByUser(ctx context.Context, userID uuid.UUID) ([]db.ProfilePermission, error)
+	DeleteProfilePermission(ctx context.Context, id uuid.UUID) error
 	CreateInvitation(ctx context.Context, profileID uuid.UUID, sharedWithUserID uuid.UUID, grantedByUserID uuid.UUID, permissions json.RawMessage, expiresAt time.Time) (db.ProfilePermission, error)
 	AcceptProfilePermission(ctx context.Context, id uuid.UUID) (db.ProfilePermission, error)
 	UpdateProfilePermissionStatus(ctx context.Context, id uuid.UUID, status string) (db.ProfilePermission, error)
@@ -105,6 +107,14 @@ func (r *profileRepository) ListProfilesByUser(ctx context.Context, userID uuid.
 
 func (r *profileRepository) ListProfilePermissionsByUser(ctx context.Context, userID uuid.UUID) ([]db.ProfilePermission, error) {
 	return r.queries.ListProfilePermissionsByUser(ctx, userID)
+}
+
+func (r *profileRepository) ListProfilePermissionsByProfile(ctx context.Context, profileID uuid.UUID) ([]db.ProfilePermission, error) {
+	return r.queries.ListProfilePermissionsByProfile(ctx, profileID)
+}
+
+func (r *profileRepository) DeleteProfilePermission(ctx context.Context, id uuid.UUID) error {
+	return r.queries.DeleteProfilePermission(ctx, id)
 }
 
 func (r *profileRepository) UpdateProfile(ctx context.Context, id uuid.UUID, name string, dateOfBirth sql.NullTime, timezone string) (db.Profile, error) {

--- a/internal/features/profiles/service/permission_checker.go
+++ b/internal/features/profiles/service/permission_checker.go
@@ -33,6 +33,19 @@ func NewPermissionCheckerWithFunc(getProfilePermission GetProfilePermissionFunc)
 	}
 }
 
+func HasPermissionInJSONB(permissions json.RawMessage, target string) bool {
+	var perms []string
+	if err := json.Unmarshal(permissions, &perms); err != nil {
+		return false
+	}
+	for _, p := range perms {
+		if p == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *permissionChecker) HasPermission(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, permission string) (bool, error) {
 	pp, err := c.getProfilePermission(ctx, db.GetProfilePermissionParams{
 		ProfileID:        profileID,

--- a/internal/features/profiles/service/profile_service.go
+++ b/internal/features/profiles/service/profile_service.go
@@ -46,6 +46,7 @@ type ProfileService interface {
 	ListProfiles(ctx context.Context, userID uuid.UUID) ([]ProfileResult, error)
 	UpdateProfile(ctx context.Context, profileID uuid.UUID, userID uuid.UUID, name *string, dateOfBirth *time.Time, timezone *string) (*ProfileResult, error)
 	DeleteProfile(ctx context.Context, profileID uuid.UUID, userID uuid.UUID) error
+	HandleAccountDeletion(ctx context.Context, userID uuid.UUID) error
 }
 
 type profileService struct {
@@ -204,6 +205,50 @@ func (s *profileService) DeleteProfile(ctx context.Context, profileID uuid.UUID,
 	}
 
 	return s.profileRepo.DeleteProfile(ctx, profileID)
+}
+
+func (s *profileService) HandleAccountDeletion(ctx context.Context, userID uuid.UUID) error {
+	permissions, err := s.profileRepo.ListProfilePermissionsByUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	for _, perm := range permissions {
+		profileID := perm.ProfileID
+
+		if HasPermissionInJSONB(perm.Permissions, "profile:owner") {
+			profilePerms, err := s.profileRepo.ListProfilePermissionsByProfile(ctx, profileID)
+			if err != nil {
+				return err
+			}
+
+			hasOtherAdmin := false
+			for _, pp := range profilePerms {
+				if pp.SharedWithUserID != userID &&
+					pp.Status == "accepted" &&
+					HasPermissionInJSONB(pp.Permissions, "profile:admin") {
+					hasOtherAdmin = true
+					break
+				}
+			}
+
+			if hasOtherAdmin {
+				if err := s.profileRepo.DeleteProfilePermission(ctx, perm.ID); err != nil {
+					return err
+				}
+			} else {
+				if err := s.profileRepo.DeleteProfile(ctx, profileID); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := s.profileRepo.DeleteProfilePermission(ctx, perm.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func toProfileResult(profile db.Profile, schedules []DoseScheduleDTO, isOwner bool) ProfileResult {

--- a/internal/features/profiles/service/profile_service_test.go
+++ b/internal/features/profiles/service/profile_service_test.go
@@ -113,6 +113,19 @@ func (m *MockProfileRepository) GetUserByID(ctx context.Context, userID uuid.UUI
 	return args.Get(0).(db.User), args.Error(1)
 }
 
+func (m *MockProfileRepository) ListProfilePermissionsByProfile(ctx context.Context, profileID uuid.UUID) ([]db.ProfilePermission, error) {
+	args := m.Called(ctx, profileID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]db.ProfilePermission), args.Error(1)
+}
+
+func (m *MockProfileRepository) DeleteProfilePermission(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 type MockDoseScheduleRepository struct {
 	mock.Mock
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -22,6 +22,8 @@ import (
 	"github.com/shuvo-paul/medminder/internal/features/auth/service"
 	"github.com/shuvo-paul/medminder/internal/features/guestaccess"
 	"github.com/shuvo-paul/medminder/internal/features/profiles"
+	profileRepo "github.com/shuvo-paul/medminder/internal/features/profiles/repository"
+	profileSvc "github.com/shuvo-paul/medminder/internal/features/profiles/service"
 	"github.com/shuvo-paul/medminder/internal/middleware"
 )
 
@@ -77,7 +79,12 @@ func New(distFS fs.FS, dbConn *sql.DB, cfg config.Config) (http.Handler, func(),
 	emailClient := email.NewEmailClient(cfg.Email)
 	email.StartEmailQueue(emailClient, 3, slog.Default())
 
-	auth.RegisterRoutes(api, dbConn, queries, auditRepo, cfg.JWT.Secret, emailClient, cfg.FrontendURL)
+	profileRepoInstance := profileRepo.NewProfileRepository(queries, dbConn)
+	scheduleRepoInstance := profileRepo.NewDoseScheduleRepository(queries)
+	permChecker := profileSvc.NewPermissionChecker(queries)
+	profileSvcInstance := profileSvc.NewProfileService(profileRepoInstance, scheduleRepoInstance, permChecker)
+
+	auth.RegisterRoutes(api, dbConn, queries, auditRepo, cfg.JWT.Secret, emailClient, cfg.FrontendURL, profileSvcInstance)
 
 	tokenSvc := service.NewTokenService(cfg.JWT.Secret)
 	profiles.RegisterRoutes(api, dbConn, queries, tokenSvc)


### PR DESCRIPTION
Implements 07-account-deletion-cascade: when a user deletes their account, profiles are either cascade-deleted (sole admin) or have only the user's permission revoked (other admins exist).